### PR TITLE
 Protect VmCtx and ID_COUNTER with RwLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +594,7 @@ dependencies = [
  "log",
  "polkavm-assembler",
  "proptest",
+ "spin",
 ]
 
 [[package]]
@@ -869,6 +880,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "sdl2"
 version = "0.35.2"
 source = "git+https://github.com/Rust-SDL2/rust-sdl2.git?rev=76748c530d4ca1fe195d3da57da7610723afb6ac#76748c530d4ca1fe195d3da57da7610723afb6ac"
@@ -954,6 +971,15 @@ dependencies = [
  "polkavm-disassembler",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ ruzstd = { version = "0.4.0", default-features = false }
 schnellru = { version = "0.2.3" }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = { version = "1.0.117" }
+spin = { version = "0.9.8", default-features = false, features = ["lock_api", "spin_mutex", "rwlock", "lazy"] }
 syn = "2.0.25"
 yansi = "0.5.1"
 

--- a/crates/polkavm-common/Cargo.toml
+++ b/crates/polkavm-common/Cargo.toml
@@ -12,6 +12,7 @@ description = "The common crate for PolkaVM"
 log = { workspace = true, optional = true }
 polkavm-assembler = { workspace = true, optional = true }
 blake3 = { workspace = true, optional = true }
+spin = { workspace = true }
 
 [features]
 default = []

--- a/crates/polkavm-zygote/Cargo.lock
+++ b/crates/polkavm-zygote/Cargo.lock
@@ -3,6 +3,22 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,6 +36,7 @@ name = "polkavm-common"
 version = "0.15.0"
 dependencies = [
  "polkavm-assembler",
+ "spin",
 ]
 
 [[package]]
@@ -32,4 +49,20 @@ version = "0.1.0"
 dependencies = [
  "polkavm-common",
  "polkavm-linux-raw",
+ "spin",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]

--- a/crates/polkavm-zygote/Cargo.toml
+++ b/crates/polkavm-zygote/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 polkavm-linux-raw = { path = "../polkavm-linux-raw" }
 polkavm-common = { path = "../polkavm-common", features = ["regmap"] }
+spin = { version = "0.9.8", default-features = false, features = ["lock_api", "spin_mutex", "rwlock", "lazy"] }
 
 [build-dependencies]
 polkavm-common = { path = "../polkavm-common" }


### PR DESCRIPTION
```
    Protect VmCtx and ID_COUNTER with RwLock
    
    AtomicU64 causes compilation issues when used as a subcrate of another
    crate when the toolchain configurations conflict. The problem was observed
    with ID_COUNTER when Polkadot SDK was compiled for riscv32emac, which could
    not be found from core.
    
    The documentation also states that:
    
    "This type is only available on platforms that support atomic loads and
    stores of u64."
    
    Address this by protecting ID_COUNTER with `spin::RwLock` and `VmCtx` with
    `std::sync::RwLock`.
```