### PR TITLE
fix: add missing `Reg::E3` to `from_usize` in `Reg` in `polkavm-linker`

### DIFF
--- a/crates/polkavm-linker/src/program_from_elf.rs
+++ b/crates/polkavm-linker/src/program_from_elf.rs
@@ -101,6 +101,7 @@ impl Reg {
             13 => Some(Reg::E0),
             14 => Some(Reg::E1),
             15 => Some(Reg::E2),
+            16 => Some(Reg::E3),
             _ => None,
         }
     }


### PR DESCRIPTION
I presume this was missed