### PR TITLE
build: Install toolchains

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,9 @@
 [toolchain]
 channel = "1.75.0"
+profile = "minimal"
+targets = [
+    "wasm32-wasi",
+    "aarch64-apple-darwin",
+    "x86_64-unknown-none"
+]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Add toolchains to rust-toolchain.xml so that they don't need to be installed manually with `rustup add component`. This further simplifies the build, in addition to linker supplying the polkavm custom targets. Start with the minimal profile, and add only mandatory components for the build.

On a fresh Rust install, this will result:

```
$ cargo b
info: syncing channel updates for '1.75.0-aarch64-apple-darwin'
info: latest update on 2023-12-28, rust version 1.75.0 (82e1608df 2023-12-21)
info: downloading component 'cargo'
info: downloading component 'clippy'
info: downloading component 'rust-std'
info: downloading component 'rust-std' for 'wasm32-wasi'
info: downloading component 'rust-std' for 'x86_64-unknown-none'
info: downloading component 'rustc'
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-std'
info: installing component 'rust-std' for 'wasm32-wasi'
info: installing component 'rust-std' for 'x86_64-unknown-none'
info: installing component 'rustc'
info: installing component 'rustfmt'
```