### PR TITLE
polkavm: Replace orc.b with an instruction sequence in the linker.

### DIFF
--- a/crates/polkavm-common/src/program.rs
+++ b/crates/polkavm-common/src/program.rs
@@ -1602,7 +1602,6 @@ define_opcodes! {
         [I_64, I_32] sign_extend_8                            = 108,
         [I_64, I_32] sign_extend_16                           = 109,
         [I_64, I_32] zero_extend_16                           = 110,
-        [I_64, I_32] or_combine_byte                          = 48,
         [I_64, I_32] reverse_byte                             = 111,
     ]
 
@@ -2413,12 +2412,6 @@ impl<'a, 'b, 'c> InstructionVisitor for InstructionFormatter<'a, 'b, 'c> {
         let d = self.format_reg(d);
         let s = self.format_reg(s);
         write!(self, "{d} = zext.h {s}")
-    }
-
-    fn or_combine_byte(&mut self, d: RawReg, s: RawReg) -> Self::ReturnTy {
-        let d = self.format_reg(d);
-        let s = self.format_reg(s);
-        write!(self, "{d} = orc.b {s}")
     }
 
     fn reverse_byte(&mut self, d: RawReg, s: RawReg) -> Self::ReturnTy {

--- a/crates/polkavm/src/compiler.rs
+++ b/crates/polkavm/src/compiler.rs
@@ -112,7 +112,6 @@ where
     step_label: Label,
     trap_label: Label,
     invalid_jump_label: Label,
-    or_combine_label: Label,
     instruction_set: RuntimeInstructionSet,
 
     _phantom: PhantomData<(S, B)>,
@@ -219,7 +218,6 @@ where
         let step_label = asm.forward_declare_label();
         let jump_table_label = asm.forward_declare_label();
         let sbrk_label = asm.forward_declare_label();
-        let or_combine_label = asm.forward_declare_label();
 
         polkavm_common::static_assert!(polkavm_common::zygote::VM_SANDBOX_MAXIMUM_NATIVE_CODE_SIZE < u32::MAX);
 
@@ -246,7 +244,6 @@ where
             step_label,
             jump_table_label,
             sbrk_label,
-            or_combine_label,
             gas_metering: config.gas_metering,
             step_tracing,
             program_counter_to_machine_code_offset_list,
@@ -261,7 +258,6 @@ where
         ArchVisitor(&mut visitor).emit_trap_trampoline();
         ArchVisitor(&mut visitor).emit_ecall_trampoline();
         ArchVisitor(&mut visitor).emit_sbrk_trampoline();
-        ArchVisitor(&mut visitor).emit_or_combine_trampoline();
 
         if step_tracing {
             ArchVisitor(&mut visitor).emit_step_trampoline();
@@ -1142,13 +1138,6 @@ where
         self.before_instruction(code_offset);
         self.gas_visitor.zero_extend_16(d, s);
         ArchVisitor(self).zero_extend_16(d, s);
-        self.after_instruction::<CONTINUE_BASIC_BLOCK>(code_offset, args_length);
-    }
-
-    fn or_combine_byte(&mut self, code_offset: u32, args_length: u32, d: RawReg, s: RawReg) -> Self::ReturnTy {
-        self.before_instruction(code_offset);
-        self.gas_visitor.or_combine_byte(d, s);
-        ArchVisitor(self).or_combine_byte(d, s);
         self.after_instruction::<CONTINUE_BASIC_BLOCK>(code_offset, args_length);
     }
 

--- a/crates/polkavm/src/gas.rs
+++ b/crates/polkavm/src/gas.rs
@@ -400,11 +400,6 @@ impl InstructionVisitor for GasVisitor {
     }
 
     #[inline(always)]
-    fn or_combine_byte(&mut self, _d: RawReg, _s: RawReg) -> Self::ReturnTy {
-        self.cost += 1;
-    }
-
-    #[inline(always)]
     fn reverse_byte(&mut self, _d: RawReg, _s: RawReg) -> Self::ReturnTy {
         self.cost += 1;
     }

--- a/crates/polkavm/src/interpreter.rs
+++ b/crates/polkavm/src/interpreter.rs
@@ -2641,42 +2641,6 @@ define_interpreter! {
         visitor.go_to_next_instruction()
     }
 
-    fn or_combine_byte_32<const DEBUG: bool>(visitor: &mut Visitor, d: Reg, s: Reg) -> Option<Target> {
-        if DEBUG {
-            log::trace!("[{}]: {}", visitor.inner.compiled_offset, asm::or_combine_byte(d, s));
-        }
-
-        let word = visitor.get32(s);
-
-        let mut result = 0;
-        for i in (0..32).step_by(8) {
-            if (word & (0xffu32 << i)) != 0 {
-                result |= 0xffu32 << i;
-            }
-        }
-
-        visitor.set32::<DEBUG>(d, result);
-        visitor.go_to_next_instruction()
-    }
-
-    fn or_combine_byte_64<const DEBUG: bool>(visitor: &mut Visitor, d: Reg, s: Reg) -> Option<Target> {
-        if DEBUG {
-            log::trace!("[{}]: {}", visitor.inner.compiled_offset, asm::or_combine_byte(d, s));
-        }
-
-        let word = visitor.get64(s);
-
-        let mut result = 0;
-        for i in (0..64).step_by(8) {
-            if (word & (0xffu64 << i)) != 0 {
-                result |= 0xffu64 << i;
-            }
-        }
-
-        visitor.set64::<DEBUG>(d, result);
-        visitor.go_to_next_instruction()
-    }
-
     fn reverse_byte_32<const DEBUG: bool>(visitor: &mut Visitor, d: Reg, s: Reg) -> Option<Target> {
         if DEBUG {
             log::trace!("[{}]: {}", visitor.inner.compiled_offset, asm::reverse_byte(d, s));
@@ -3959,14 +3923,6 @@ impl<'a, const DEBUG: bool> InstructionVisitor for Compiler<'a, DEBUG> {
             emit!(self, zero_extend_16_64(d, s));
         } else {
             emit!(self, zero_extend_16_32(d, s));
-        }
-    }
-
-    fn or_combine_byte(&mut self, d: RawReg, s: RawReg) -> Self::ReturnTy {
-        if self.module.blob().is_64_bit() {
-            emit!(self, or_combine_byte_64(d, s));
-        } else {
-            emit!(self, or_combine_byte_32(d, s));
         }
     }
 


### PR DESCRIPTION
And get rid orc.b emulation code from the interpreter and the recompiler.

We are making this change because orc.b is rarely used and a very complicated instruction in itself, we don't need to support or upstream such a complicated instruction to Polkavm. Therefore let's emulate the instruction within the linker.

In addition, we are adding a warn print for the linker user to make them aware that orc.b is being replaced with an instruction sequence, and any perf benefit that the user is expecting would not be visible.