### PR TITLE
fuzz: Add a linker fuzzer

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +22,12 @@ checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "bitflags"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "cc"
@@ -23,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +56,69 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "jobserver"
@@ -60,16 +147,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "polkavm"
@@ -104,6 +222,21 @@ dependencies = [
  "arbitrary",
  "libfuzzer-sys",
  "polkavm",
+ "polkavm-linker",
+]
+
+[[package]]
+name = "polkavm-linker"
+version = "0.19.0"
+dependencies = [
+ "dirs",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "object",
+ "polkavm-common",
+ "regalloc2",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -129,10 +262,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
+dependencies = [
+ "hashbrown 0.13.2",
+ "log",
+ "rustc-hash",
+ "slice-group-by",
+ "smallvec",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
@@ -146,7 +333,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,6 +15,9 @@ libfuzzer-sys = "0.4"
 path = "../crates/polkavm"
 features = ["export-internals-for-testing"]
 
+[dependencies.polkavm-linker]
+path = "../crates/polkavm-linker"
+
 [[bin]]
 name = "fuzz_shm_allocator"
 path = "fuzz_targets/fuzz_shm_allocator.rs"
@@ -25,6 +28,13 @@ bench = false
 [[bin]]
 name = "fuzz_generic_allocator"
 path = "fuzz_targets/fuzz_generic_allocator.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_linker"
+path = "fuzz_targets/fuzz_linker.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/fuzz_linker.rs
+++ b/fuzz/fuzz_targets/fuzz_linker.rs
@@ -1,0 +1,372 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+
+#[repr(u8)]
+#[derive(Arbitrary, Debug)]
+pub enum Reg {
+    Zero = 0,
+    RA,
+    SP,
+    GP,
+    TP,
+    T0,
+    T1,
+    T2,
+    S0,
+    S1,
+    A0,
+    A1,
+    A2,
+    A3,
+    A4,
+    A5,
+}
+
+#[derive(Arbitrary, Debug)]
+enum RegKind {
+    CountLeadingZeroBits,
+    CountLeadingZeroBitsInWord,
+    CountSetBits,
+    CountSetBitsInWord,
+    CountTrailingZeroBits,
+    CountTrailingZeroBitsInWord,
+    OrCombineByte,
+    ReverseByte,
+    SignExtend8,
+    SignExtend16,
+    ZeroExtend16,
+}
+
+#[derive(Arbitrary, Debug)]
+enum RegRegKind {
+    Add32AndSignExtend,
+    Add64,
+    Sub32AndSignExtend,
+    Sub64,
+    Mul32AndSignExtend,
+    Mul64,
+    MulUpperSignedSigned64,
+    MulUpperSignedUnsigned64,
+    MulUpperUnsignedUnsigned64,
+    Div32AndSignExtend,
+    Div64,
+    DivUnsigned32AndSignExtend,
+    DivUnsigned64,
+    Rem32AndSignExtend,
+    Rem64,
+    RemUnsigned32AndSignExtend,
+    RemUnsigned64,
+    Xor64,
+    Or64,
+    And64,
+    ShiftLogicalLeft32AndSignExtend,
+    ShiftLogicalLeft64,
+    ShiftLogicalRight32AndSignExtend,
+    ShiftLogicalRight64,
+    ShiftArithmeticRight32AndSignExtend,
+    ShiftArithmeticRight64,
+    SetLessThanSigned64,
+    SetLessThanUnsigned64,
+    AndInverted,
+    OrInverted,
+    Xnor,
+    Maximum,
+    MaximumUnsigned,
+    Minimum,
+    MinimumUnsigned,
+    RotateLeft32AndSignExtend,
+    RotateLeft64,
+    RotateRight32AndSignExtend,
+    RotateRight64,
+}
+
+#[derive(Arbitrary, Debug)]
+enum RegImmKind {
+    Add32AndSignExtend,
+    Add64,
+    SetLessThanSigned64,
+    SetLessThanUnsigned64,
+    Xor64,
+    Or64,
+    And64,
+    ShiftLogicalLeft32AndSignExtend,
+    ShiftLogicalLeft64,
+    ShiftLogicalRight32AndSignExtend,
+    ShiftLogicalRight64,
+    ShiftArithmeticRight32AndSignExtend,
+    ShiftArithmeticRight64,
+    RotateRight32AndSignExtend,
+    RotateRight64,
+}
+
+#[derive(Arbitrary, Debug)]
+enum Instruction {
+    Reg {
+        kind: RegKind,
+        dst: Reg,
+        src: Reg
+    },
+    RegReg {
+        kind: RegRegKind,
+        dst: Reg,
+        src1: Reg,
+        src2: Reg,
+    },
+    RegImm {
+        kind: RegImmKind,
+        dst: Reg,
+        src: Reg,
+        imm: u32,
+    },
+}
+
+fn serialize_instructions(data: Vec<Instruction>) -> Vec<u8> {
+    let mut buffer = Vec::new();
+    for instruction in data {
+        match instruction {
+            Instruction::Reg { kind, dst, src } => {
+                let mut encoding: u32 = match kind {
+                    RegKind::CountLeadingZeroBits       => 0b0110000_00000_00000_001_00000_0010011,
+                    RegKind::CountLeadingZeroBitsInWord => 0b0110000_00000_00000_001_00000_0011011,
+                    RegKind::CountSetBits               => 0b0110000_00010_00000_001_00000_0010011,
+                    RegKind::CountSetBitsInWord         => 0b0110000_00010_00000_001_00000_0011011,
+                    RegKind::CountTrailingZeroBits      => 0b0110000_00001_00000_001_00000_0010011,
+                    RegKind::CountTrailingZeroBitsInWord=> 0b0110000_00001_00000_001_00000_0011011,
+                    RegKind::OrCombineByte              => 0b0010100_00111_00000_101_00000_0010011,
+                    RegKind::ReverseByte                => 0b0110101_11000_00000_101_00000_0010011,
+                    RegKind::SignExtend8                => 0b0110000_00100_00000_001_00000_0010011,
+                    RegKind::SignExtend16               => 0b0110000_00101_00000_001_00000_0010011,
+                    RegKind::ZeroExtend16               => 0b0000100_00000_00000_100_00000_0111011,
+                };
+
+                encoding |= (dst as u32) << 7;
+                encoding |= (src as u32) << 15;
+                buffer.extend_from_slice(&encoding.to_le_bytes());
+            }
+            Instruction::RegReg { kind, dst, src1, src2 } => {
+                let mut encoding: u32 = match kind {
+                    RegRegKind::Add32AndSignExtend                      => 0b0000000_00000_00000_000_00000_0111011,
+                    RegRegKind::Sub32AndSignExtend                      => 0b0100000_00000_00000_000_00000_0111011,
+                    RegRegKind::Mul32AndSignExtend                      => 0b0000001_00000_00000_000_00000_0111011,
+                    RegRegKind::Div32AndSignExtend                      => 0b0000001_00000_00000_100_00000_0111011,
+                    RegRegKind::DivUnsigned32AndSignExtend              => 0b0000001_00000_00000_101_00000_0111011,
+                    RegRegKind::Rem32AndSignExtend                      => 0b0000001_00000_00000_110_00000_0111011,
+                    RegRegKind::RemUnsigned32AndSignExtend              => 0b0000001_00000_00000_111_00000_0111011,
+                    RegRegKind::ShiftLogicalLeft32AndSignExtend         => 0b0000000_00000_00000_001_00000_0111011,
+                    RegRegKind::ShiftLogicalRight32AndSignExtend        => 0b0000001_00000_00000_000_00000_0111011,
+                    RegRegKind::ShiftArithmeticRight32AndSignExtend     => 0b0100000_00000_00000_101_00000_0111011,
+                    RegRegKind::RotateLeft32AndSignExtend               => 0b0110000_00000_00000_001_00000_0111011,
+                    RegRegKind::RotateRight32AndSignExtend              => 0b0110000_00000_00000_101_00000_0111011,
+
+                    RegRegKind::Add64                                   => 0b0000000_00000_00000_000_00000_0110011,
+                    RegRegKind::Sub64                                   => 0b0100000_00000_00000_000_00000_0110011,
+                    RegRegKind::Mul64                                   => 0b0000001_00000_00000_000_00000_0110011,
+                    RegRegKind::Div64                                   => 0b0000001_00000_00000_100_00000_0110011,
+                    RegRegKind::DivUnsigned64                           => 0b0000001_00000_00000_101_00000_0110011,
+                    RegRegKind::Rem64                                   => 0b0000001_00000_00000_110_00000_0110011,
+                    RegRegKind::RemUnsigned64                           => 0b0000001_00000_00000_111_00000_0110011,
+                    RegRegKind::ShiftLogicalLeft64                      => 0b0000000_00000_00000_001_00000_0110011,
+                    RegRegKind::ShiftLogicalRight64                     => 0b0000000_00000_00000_101_00000_0110011,
+                    RegRegKind::ShiftArithmeticRight64                  => 0b0100000_00000_00000_101_00000_0110011,
+                    RegRegKind::RotateLeft64                            => 0b0110000_00000_00000_001_00000_0110011,
+                    RegRegKind::RotateRight64                           => 0b0110000_00000_00000_101_00000_0110011,
+
+                    RegRegKind::MulUpperSignedSigned64                  => 0b0000001_00000_00000_001_00000_0110011,
+                    RegRegKind::MulUpperSignedUnsigned64                => 0b0000001_00000_00000_010_00000_0110011,
+                    RegRegKind::MulUpperUnsignedUnsigned64              => 0b0000001_00000_00000_011_00000_0110011,
+
+                    RegRegKind::SetLessThanSigned64                     => 0b0000000_00000_00000_010_00000_0110011,
+                    RegRegKind::SetLessThanUnsigned64                   => 0b0000000_00000_00000_011_00000_0110011,
+                    RegRegKind::Xor64                                   => 0b0000000_00000_00000_100_00000_0110011,
+                    RegRegKind::Or64                                    => 0b0000000_00000_00000_110_00000_0110011,
+                    RegRegKind::And64                                   => 0b0000000_00000_00000_111_00000_0110011,
+
+                    RegRegKind::Minimum                                 => 0b0000101_00000_00000_100_00000_0110011,
+                    RegRegKind::MinimumUnsigned                         => 0b0000101_00000_00000_101_00000_0110011,
+                    RegRegKind::Maximum                                 => 0b0000101_00000_00000_110_00000_0110011,
+                    RegRegKind::MaximumUnsigned                         => 0b0000101_00000_00000_111_00000_0110011,
+                    RegRegKind::Xnor                                    => 0b0100000_00000_00000_100_00000_0110011,
+                    RegRegKind::OrInverted                              => 0b0100000_00000_00000_110_00000_0110011,
+                    RegRegKind::AndInverted                             => 0b0100000_00000_00000_111_00000_0110011,
+                };
+
+                encoding |= (dst as u32) << 7;
+                encoding |= (src1 as u32) << 15;
+                encoding |= (src2 as u32) << 20;
+                buffer.extend_from_slice(&encoding.to_le_bytes());
+            }
+            Instruction::RegImm { kind, dst, src, imm } => {
+                let mut encoding: u32 = match kind {
+                    RegImmKind::Add32AndSignExtend                  => 0b0000000_00000_00000_000_00000_0011011,
+                    RegImmKind::ShiftLogicalLeft32AndSignExtend     => 0b0000000_00000_00000_001_00000_0011011,
+                    RegImmKind::ShiftLogicalRight32AndSignExtend    => 0b0000000_00000_00000_101_00000_0011011,
+                    RegImmKind::ShiftArithmeticRight32AndSignExtend => 0b0100000_00000_00000_101_00000_0011011,
+                    RegImmKind::RotateRight32AndSignExtend          => 0b0110000_00000_00000_101_00000_0011011,
+
+                    RegImmKind::ShiftLogicalLeft64                  => 0b0000000_00000_00000_001_00000_0010011,
+                    RegImmKind::ShiftLogicalRight64                 => 0b0000000_00000_00000_101_00000_0010011,
+                    RegImmKind::ShiftArithmeticRight64              => 0b0100000_00000_00000_101_00000_0010011,
+
+                    RegImmKind::RotateRight64                       => 0b0110000_00000_00000_101_00000_0010011,
+
+                    RegImmKind::Add64                               => 0b0000000_00000_00000_000_00000_0010011,
+                    RegImmKind::SetLessThanSigned64                 => 0b0000000_00000_00000_010_00000_0010011,
+                    RegImmKind::SetLessThanUnsigned64               => 0b0000000_00000_00000_011_00000_0010011,
+                    RegImmKind::Xor64                               => 0b0000000_00000_00000_100_00000_0010011,
+                    RegImmKind::Or64                                => 0b0000000_00000_00000_110_00000_0010011,
+                    RegImmKind::And64                               => 0b0000000_00000_00000_111_00000_0010011,
+                };
+
+                let imm_mask: u32 = match kind {
+                    RegImmKind::Add32AndSignExtend => 0b111111111111,
+                    _ => 0b11111,
+                };
+
+                encoding |= (dst as u32) << 7;
+                encoding |= (src as u32) << 15;
+                encoding |= ((imm & imm_mask) as u32) << 20;
+                buffer.extend_from_slice(&encoding.to_le_bytes());
+            }
+        }
+    }
+    buffer
+}
+
+fuzz_target!(|instructions: Vec<Instruction>| {
+    let bytecode = serialize_instructions(instructions);
+    let program = create_minimal_elf(&bytecode);
+
+    let mut config = polkavm_linker::Config::default();
+    config.set_strip(true);
+    config.set_optimize(true);
+
+    polkavm_linker::program_from_elf(config, &program).unwrap();
+});
+
+#[repr(C)]
+struct Elf64Ehdr {
+    e_ident: [u8; 16],
+    e_type: u16,
+    e_machine: u16,
+    e_version: u32,
+    e_entry: u64,
+    e_phoff: u64,
+    e_shoff: u64,
+    e_flags: u32,
+    e_ehsize: u16,
+    e_phentsize: u16,
+    e_phnum: u16,
+    e_shentsize: u16,
+    e_shnum: u16,
+    e_shstrndx: u16,
+}
+
+#[repr(C)]
+struct Elf64Phdr {
+    p_type: u32,
+    p_flags: u32,
+    p_offset: u64,
+    p_vaddr: u64,
+    p_paddr: u64,
+    p_filesz: u64,
+    p_memsz: u64,
+    p_align: u64,
+}
+
+#[repr(C)]
+struct Elf64Shdr {
+    sh_name: u32,
+    sh_type: u32,
+    sh_flags: u64,
+    sh_addr: u64,
+    sh_offset: u64,
+    sh_size: u64,
+    sh_link: u32,
+    sh_info: u32,
+    sh_addralign: u64,
+    sh_entsize: u64,
+}
+
+fn create_minimal_elf(bytecode: &[u8]) -> Vec<u8> {
+
+    assert!(std::mem::size_of::<Elf64Ehdr>() == 64);
+    assert!(std::mem::size_of::<Elf64Phdr>() == 56);
+    assert!(std::mem::size_of::<Elf64Shdr>() == 64);
+
+    let elf_hdr = Elf64Ehdr {
+        e_ident: [
+            0x7f, b'E', b'L', b'F',         // Magic number
+            2,                              // 64-bit
+            1,                              // Little-endian
+            1,                              // ELF version
+            0,                              // ABI
+            0,                              // ABI version
+            0, 0, 0, 0, 0, 0, 0,
+        ],
+        e_type: 2,                          // Executable file
+        e_machine: 0xF3,                    // RISC-V architecture
+        e_version: 1,                       // ELF version
+        e_entry: 0x1000,                    // Entry point address
+        e_phoff: 0,                         // Program header table file offset
+        e_shoff: 64,                        // Section header table file offset
+        e_flags: 0,                         // Processor-specific flags
+        e_ehsize: 64,                       // ELF header size
+        e_phentsize: 0,                     // Program header table entry size
+        e_phnum: 0,                         // Number of program header entries
+        e_shentsize: 64,                    // Section header table entry size
+        e_shnum: 3,                         // Number of section header entries
+        e_shstrndx: 2,                      // Section header string table index
+    };
+
+    let null_shdr = Elf64Shdr {
+        sh_name: 0,                         // Section name (index into the section header string table)
+        sh_type: 0,                         // Section type (NULL)
+        sh_flags: 0,                        // Section flags
+        sh_addr: 0,                         // Section virtual address
+        sh_offset: 0,                       // Section file offset
+        sh_size: 0,                         // Section size in file
+        sh_link: 0,                         // Link to another section
+        sh_info: 0,                         // Additional section information
+        sh_addralign: 0,                    // Section alignment
+        sh_entsize: 0,                      // Entry size if section holds table
+    };
+
+    let text_shdr = Elf64Shdr {
+        sh_name: 1,                         // Section name (index into the section header string table)
+        sh_type: 1,                         // Section type (PROGBITS)
+        sh_flags: 6,                        // Section flags (ALLOC + EXECINSTR)
+        sh_addr: 0x1000,                    // Section virtual address
+        sh_offset: 64 * 4 + 32,             // Section file offset
+        sh_size: bytecode.len() as u64,     // Section size in file
+        sh_link: 0,                         // Link to another section
+        sh_info: 0,                         // Additional section information
+        sh_addralign: 4,                    // Section alignment
+        sh_entsize: 0,                      // Entry size if section holds table
+    };
+
+    let shstrtab_shdr = Elf64Shdr {
+        sh_name: 7,                         // Section name (index into the section header string table)
+        sh_type: 3,                         // Section type (STRTAB)
+        sh_flags: 0,                        // Section flags
+        sh_addr: 0,                         // Section virtual address
+        sh_offset: 64 * 4,                  // Section file offset
+        sh_size: 32,                        // Section size in file
+        sh_link: 0,                         // Link to another section
+        sh_info: 0,                         // Additional section information
+        sh_addralign: 1,                    // Section alignment
+        sh_entsize: 0,                      // Entry size if section holds table
+    };
+
+    let mut program = Vec::new();
+    program.extend_from_slice(unsafe { std::slice::from_raw_parts((&elf_hdr as *const Elf64Ehdr) as *const u8, std::mem::size_of::<Elf64Ehdr>()) });
+    program.extend_from_slice(unsafe { std::slice::from_raw_parts((&null_shdr as *const Elf64Shdr) as *const u8, std::mem::size_of::<Elf64Shdr>()) });
+    program.extend_from_slice(unsafe { std::slice::from_raw_parts((&text_shdr as *const Elf64Shdr) as *const u8, std::mem::size_of::<Elf64Shdr>()) });
+    program.extend_from_slice(unsafe { std::slice::from_raw_parts((&shstrtab_shdr as *const Elf64Shdr) as *const u8, std::mem::size_of::<Elf64Shdr>()) });
+    program.extend_from_slice(b"\0.text\0.shstrtab\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+    program.extend_from_slice(&bytecode);
+
+    program
+}


### PR DESCRIPTION
We add a fuzzer for the linker, that uses RISC-V instruction encoding logic to create a sequence of valid instructions. Which then is compiled into a ELF binary and passed to the linker.

Expectation here is that the fuzzer would always generate a valid ELF binary with valid instructions, and the linker should be able to link it without any issues.

Currently the ELF binary is limited to one section (.text) and no symbols. We may want to extend that in the future.


Note: I saw some crashes that the fuzzer has reported and I am working on investigating those issues.