### PR TITLE
polkavm-linker: Fix multiple issues reported by the fuzzer

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "polkavm-linker"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "dirs",
  "gimli",

--- a/fuzz/fuzz_targets/fuzz_linker.rs
+++ b/fuzz/fuzz_targets/fuzz_linker.rs
@@ -8,21 +8,22 @@ use libfuzzer_sys::fuzz_target;
 #[derive(Arbitrary, Debug)]
 pub enum Reg {
     Zero = 0,
-    RA,
-    SP,
-    GP,
-    TP,
-    T0,
-    T1,
-    T2,
-    S0,
-    S1,
-    A0,
-    A1,
-    A2,
-    A3,
-    A4,
-    A5,
+    RA = 1,
+    SP = 2,
+    // These registers are not supported
+    // GP = 3,
+    // TP = 4,
+    T0 = 5,
+    T1 = 6,
+    T2 = 7,
+    S0 = 8,
+    S1 = 9,
+    A0 = 10,
+    A1 = 11,
+    A2 = 12,
+    A3 = 13,
+    A4 = 14,
+    A5 = 15,
 }
 
 #[derive(Arbitrary, Debug)]


### PR DESCRIPTION
The fuzzer reported several valid bugs, this patch takes care of them.

Following categories of bugs were reported:

1. RegKind with a zero register.
```
[
    Reg {
        kind: ReverseByte,
        dst: A2,
        src: Zero,
    },
]
```

2. apply() does not implement Rem32AndSignExtend and RemUnsigned32AndSignExtend.
```
[
    RegReg {
        kind: RemUnsigned32AndSignExtend,
        dst: A2,
        src1: T0,
        src2: Zero,
    },
]
```

3. apply() does not implement Div32AndSignExtend and DivUnsigned32AndSignExtend/
```
[
    RegReg {
        kind: DivUnsigned32AndSignExtend,
        dst: T1,
        src1: T2,
        src2: Zero,
    },
]
```

4. apply() does not implement Rem*/Div* Zero src1 register case.
```
[
    RegReg {
        kind: Rem64,
        dst: S0,
        src1: Zero,
        src2: A3,
    },
]
```