### PR TITLE
support `DW_AT_high_pc` when its data type is data8

### DIFF
--- a/crates/polkavm-linker/src/dwarf.rs
+++ b/crates/polkavm-linker/src/dwarf.rs
@@ -344,7 +344,7 @@ impl<R: gimli::Reader> AttributeParser<R> {
                     value: gimli::AttributeValue::Data8(value),
                     ..
                 } => {
-                    log::trace!("  = DW_AT_low_pc + {value} (size/data4)");
+                    log::trace!("  = DW_AT_low_pc + {value} (size/data8)");
                     self.size = Some(value);
                     Ok(())
                 }

--- a/crates/polkavm-linker/src/dwarf.rs
+++ b/crates/polkavm-linker/src/dwarf.rs
@@ -340,6 +340,14 @@ impl<R: gimli::Reader> AttributeParser<R> {
                     self.size = Some(u64::from(value));
                     Ok(())
                 }
+                AttributeValue {
+                    value: gimli::AttributeValue::Data8(value),
+                    ..
+                } => {
+                    log::trace!("  = DW_AT_low_pc + {value} (size/data4)");
+                    self.size = Some(value);
+                    Ok(())
+                }
                 _ => Err(UnsupportedValue(value)),
             },
             gimli::DW_AT_ranges => match value {


### PR DESCRIPTION
### Description
- Add an extra arm when `gimli::DW_AT_high_pc` is of type `Data8`

### Issue
- https://github.com/paritytech/polkavm/issues/274