### PR TITLE
polkavm-linker: Handle relocation being stored into the Zero register

### DIFF
--- a/crates/polkavm-linker/src/program_from_elf.rs
+++ b/crates/polkavm-linker/src/program_from_elf.rs
@@ -8481,11 +8481,11 @@ where
                                 src: _,
                                 imm: _,
                             } => {
-                                let Some(dst) = cast_reg_non_zero(dst)? else {
-                                    return Err(ProgramFromElfError::other("R_RISCV_LO12_I with a zero destination register"));
-                                };
-
-                                InstExt::Basic(BasicInst::LoadAddress { dst, target })
+                                if let Some(dst) = cast_reg_non_zero(dst)? {
+                                    InstExt::Basic(BasicInst::LoadAddress { dst, target })
+                                } else {
+                                    InstExt::nop()
+                                }
                             }
                             Inst::RegImm {
                                 kind: RegImmKind::Add64,
@@ -8493,11 +8493,11 @@ where
                                 src: _,
                                 imm: _,
                             } => {
-                                let Some(dst) = cast_reg_non_zero(dst)? else {
-                                    return Err(ProgramFromElfError::other("R_RISCV_LO12_I with a zero destination register"));
-                                };
-
-                                InstExt::Basic(BasicInst::LoadAddress { dst, target })
+                                if let Some(dst) = cast_reg_non_zero(dst)? {
+                                    InstExt::Basic(BasicInst::LoadAddress { dst, target })
+                                } else {
+                                    InstExt::nop()
+                                }
                             }
                             Inst::Load {
                                 kind,
@@ -8505,11 +8505,11 @@ where
                                 base: _,
                                 offset: _,
                             } => {
-                                let Some(dst) = cast_reg_non_zero(dst)? else {
-                                    return Err(ProgramFromElfError::other("R_RISCV_LO12_I with a zero destination register"));
-                                };
-
-                                InstExt::Basic(BasicInst::LoadAbsolute { kind, dst, target })
+                                if let Some(dst) = cast_reg_non_zero(dst)? {
+                                    InstExt::Basic(BasicInst::LoadAbsolute { kind, dst, target })
+                                } else {
+                                    InstExt::nop()
+                                }
                             }
                             _ => {
                                 return Err(ProgramFromElfError::other(format!(


### PR DESCRIPTION
Compiler can generate relocations that store the value into the Zero register. We should swap it with a "nop".

Fixes: #279 