### PR TITLE
polkavm-linker: Add a return type to the import trampoline

### DIFF
--- a/crates/polkavm-derive-impl/src/abi_support_impl/common_private.rs
+++ b/crates/polkavm-derive-impl/src/abi_support_impl/common_private.rs
@@ -118,6 +118,14 @@ pub type ReturnTy = u64;
 #[cfg(all(target_arch = "riscv64", target_feature = "e"))]
 pub type ReturnTy = u128;
 
+#[cfg(all(target_arch = "riscv32", target_feature = "e"))]
+#[repr(C, packed(1))]
+pub struct PackedReturnTy(pub u32, pub u32);
+
+#[cfg(all(target_arch = "riscv64", target_feature = "e"))]
+#[repr(C, packed(1))]
+pub struct PackedReturnTy(pub u64, pub u64);
+
 #[cfg(all(any(target_arch = "riscv32", target_arch = "riscv64"), target_feature = "e"))]
 #[inline(always)]
 pub extern fn pack_return_ty(a0: Reg, a1: Reg) -> ReturnTy {
@@ -154,7 +162,7 @@ impl IntoTuple for (Reg, Reg) {
 
 #[cfg(all(any(target_arch = "riscv32", target_arch = "riscv64"), target_feature = "e"))]
 pub trait ImportSymbol {
-    extern fn trampoline(a0: Reg, a1: Reg, a2: Reg, a3: Reg, a4: Reg, a5: Reg);
+    extern fn trampoline(a0: Reg, a1: Reg, a2: Reg, a3: Reg, a4: Reg, a5: Reg) -> PackedReturnTy;
 }
 
 #[cfg(all(any(target_arch = "riscv32", target_arch = "riscv64"), target_feature = "e"))]

--- a/crates/polkavm-derive-impl/src/import.rs
+++ b/crates/polkavm-derive-impl/src/import.rs
@@ -315,43 +315,49 @@ pub fn polkavm_import(attributes: ImportBlockAttributes, input: syn::ItemForeign
 
                         #[cfg(target_arch = "riscv32")]
                         impl #abi_path::private::ImportSymbol for Sym {
-                            extern fn trampoline(a0: u32, a1: u32, a2: u32, a3: u32, a4: u32, a5: u32) {
+                            extern fn trampoline(a0: u32, a1: u32, a2: u32, a3: u32, a4: u32, a5: u32) -> #abi_path::private::PackedReturnTy {
+                                let mut out0: u32;
+                                let mut out1: u32;
                                 unsafe {
                                     core::arch::asm!(
                                         ".insn r 0xb, 0, 0, zero, zero, zero\n",
                                         ".4byte {metadata}\n",
-                                        "ret\n",
                                         in("a0") a0,
                                         in("a1") a1,
                                         in("a2") a2,
                                         in("a3") a3,
                                         in("a4") a4,
                                         in("a5") a5,
-                                        options(noreturn),
+                                        lateout("a0") out0,
+                                        lateout("a1") out1,
                                         metadata = sym METADATA,
                                     );
                                 }
+                                #abi_path::private::PackedReturnTy(out0, out1)
                             }
                         }
 
                         #[cfg(target_arch = "riscv64")]
                         impl #abi_path::private::ImportSymbol for Sym {
-                            extern fn trampoline(a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64) {
+                            extern fn trampoline(a0: u64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64) -> #abi_path::private::PackedReturnTy {
+                                let mut out0: u64;
+                                let mut out1: u64;
                                 unsafe {
                                     core::arch::asm!(
                                         ".insn r 0xb, 0, 0, zero, zero, zero\n",
                                         ".8byte {metadata}\n",
-                                        "ret\n",
                                         in("a0") a0,
                                         in("a1") a1,
                                         in("a2") a2,
                                         in("a3") a3,
                                         in("a4") a4,
                                         in("a5") a5,
-                                        options(noreturn),
+                                        lateout("a0") out0,
+                                        lateout("a1") out1,
                                         metadata = sym METADATA,
                                     );
                                 }
+                                #abi_path::private::PackedReturnTy(out0, out1)
                             }
                         }
 


### PR DESCRIPTION
and mark the return register properly.

We are seeing that in some debug builds trampoline subroutine is not inlined, which causes epilogue and prologue to be generated. Further corrupting the stack pointer and jumping to an incorrect address when returning from the subroutine.

We fix this by adding a return type to the trampoline subroutine and marking the return register properly, and therefore removing the "noreturn" attribute from the trampoline subroutine.

Fixes: #277