### PR TITLE
fuzz/fuzz_polkavm: Add correctness fuzzer for the interpreter

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -43,8 +43,8 @@ doc = false
 bench = false
 
 [[bin]]
-name = "fuzz_interpreter"
-path = "fuzz_targets/fuzz_interpreter.rs"
+name = "fuzz_polkavm"
+path = "fuzz_targets/fuzz_polkavm.rs"
 test = false
 doc = false
 bench = false


### PR DESCRIPTION
We run both recompiler and interpreter side by side in the fuzzing harness. And then compare the results of both. This is a simple fuzzer that runs the interpreter on the input and checks if the result is the same as the recompiler.