### PR TITLE
sandbox: Fix generic sandbox

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,8 @@ jobs:
       run: rustup component add clippy
     - name: Install clippy (zygote toolchain)
       run: cd crates/polkavm-zygote && rustup component add clippy
+    - name: Install clippy (guest-programs toolchain)
+      run: cd guest-programs && rustup component add clippy
     - name: Run clippy
       run: ./ci/jobs/clippy.sh
   rustfmt:
@@ -91,6 +93,8 @@ jobs:
       run: rustup component add rustfmt
     - name: Install rustfmt (zygote toolchain)
       run: cd crates/polkavm-zygote && rustup component add rustfmt
+    - name: Install rustfmt (guest-programs toolchain)
+      run: cd guest-programs && rustup component add rustfmt
     - name: Run rustfmt
       run: ./ci/jobs/rustfmt.sh
   pallet-revive-tests:

--- a/ci/jobs/build-and-test.sh
+++ b/ci/jobs/build-and-test.sh
@@ -19,5 +19,11 @@ RUSTC_BOOTSTRAP=1 cargo test --no-default-features -p polkavm
 echo ">> cargo test (module-cache)"
 cargo test --features module-cache -p polkavm
 
+echo ">> cargo test (generic-sandbox)"
+cargo test --features generic-sandbox -p polkavm -- \
+    tests::compiler_generic_basic_test \
+    tests::compiler_generic_simple_test \
+    tests::compiler_generic_riscv_ 
+
 echo ">> cargo run generate (spectool)"
 cargo run -p spectool generate

--- a/crates/polkavm/src/api.rs
+++ b/crates/polkavm/src/api.rs
@@ -63,6 +63,16 @@ if_compiler_is_supported! {
             self.map_err(|error| Error::from(error).context(message))
         }
     }
+
+    #[cfg(feature = "generic-sandbox")]
+    use crate::sandbox::generic;
+
+    #[cfg(feature = "generic-sandbox")]
+    impl<T> IntoResult<T> for Result<T, generic::Error> {
+        fn into_result(self, message: &str) -> Result<T, Error> {
+            self.map_err(|error| Error::from(error).context(message))
+        }
+    }
 }
 
 impl<T> IntoResult<T> for T {

--- a/crates/polkavm/src/compiler/amd64.rs
+++ b/crates/polkavm/src/compiler/amd64.rs
@@ -825,6 +825,11 @@ where
     pub(crate) fn emit_gas_metering_stub(&mut self, kind: GasMeteringKind) {
         let origin = self.asm.len();
 
+        if matches!(S::KIND, SandboxKind::Generic) {
+            // The generic sandbox doesn't support gas metering.
+            return;
+        }
+
         // 49 81 6f 60 ff ff ff 7f   sub qword [r15+0x60], 0x7fffffff
         self.push(sub((Self::vmctx_field(S::offset_table().gas), imm64(i32::MAX))));
         debug_assert_eq!(GAS_COST_OFFSET, self.asm.len() - origin - 4); // Offset to bring us from the start of the stub to the gas cost.
@@ -844,6 +849,11 @@ where
     }
 
     pub(crate) fn emit_weight(&mut self, offset: usize, cost: u32) {
+        if matches!(S::KIND, SandboxKind::Generic) {
+            // The generic sandbox doesn't support gas metering.
+            return;
+        }
+
         let length = sub((Self::vmctx_field(S::offset_table().gas), imm64(i32::MAX))).len();
         let xs = cost.to_le_bytes();
         self.asm.code_mut()[offset + length - 4..offset + length].copy_from_slice(&xs);

--- a/crates/polkavm/src/error.rs
+++ b/crates/polkavm/src/error.rs
@@ -56,6 +56,17 @@ if_compiler_is_supported! {
             Self(ErrorKind::Owned(error.to_string()))
         }
     }
+
+    #[cfg(feature = "generic-sandbox")]
+    use crate::sandbox::generic;
+
+    #[cfg(feature = "generic-sandbox")]
+    impl From<generic::Error> for Error {
+        #[cold]
+        fn from(error: generic::Error) -> Self {
+            Self(ErrorKind::Owned(error.to_string()))
+        }
+    }
 }
 
 impl Error {


### PR DESCRIPTION
We have been ignoring the generic sandbox for a while now. This commit fixes the generic sandbox by implementing the updated Sandbox trait and removing the old code.

Sandbox is used to provide isolation and interface to execute compiler generated native code directly on the CPU. Generic Sandbox unlike Linux Sandbox directly runs code inside Sandbox process by modifying process memory and jumping directly to the guest code.

We implemented a bunch of interface but still some things are missing, such as gas metering, aux data access and dynamic paging.

However, now we can use the generic sandbox for testing and it is able to run 90% of our tests.

**Testing**
test result: FAILED. 573 passed; 55 failed; 0 ignored; 0 measured; 2529 filtered out; finished in 12.55s