### PR TITLE
interpreter: Fix out-of-range execution ProgramCounter

### DIFF
--- a/ci/jobs/fuzz.sh
+++ b/ci/jobs/fuzz.sh
@@ -11,3 +11,9 @@ cargo fuzz run fuzz_generic_allocator -- -runs=1000000
 
 echo ">> cargo fuzz run (fuzz_shm_allocator)"
 cargo fuzz run fuzz_shm_allocator -- -runs=1000000
+
+echo ">> cargo fuzz run (fuzz_linker)"
+cargo fuzz run fuzz_linker -- -runs=10000
+
+echo ">> cargo fuzz run (fuzz_polkavm)"
+cargo fuzz run fuzz_polkavm -- -runs=10000

--- a/crates/polkavm/src/tests.rs
+++ b/crates/polkavm/src/tests.rs
@@ -692,6 +692,28 @@ fn simple_test(engine_config: Config) {
     assert_eq!(instance.reg(Reg::A1), 100);
 }
 
+fn out_of_range_execution(engine_config: Config) {
+    let _ = env_logger::try_init();
+    let engine = Engine::new(&engine_config).unwrap();
+    let mut builder = ProgramBlobBuilder::new();
+    builder.add_export_by_basic_block(0, b"main");
+    builder.set_code(&[asm::load_imm(A0, 1), asm::load_imm(A0, 2), asm::branch_eq_imm(RA, 0, 0)], &[]);
+
+    let blob = ProgramBlob::parse(builder.into_vec().unwrap().into()).unwrap();
+    let module = Module::from_blob(&engine, &ModuleConfig::new(), blob).unwrap();
+    let next_offsets: Vec<_> = module
+        .blob()
+        .instructions(DefaultInstructionSet::default())
+        .map(|inst| inst.next_offset)
+        .collect();
+
+    let mut instance = module.instantiate().unwrap();
+    instance.set_reg(Reg::RA, crate::RETURN_TO_HOST);
+    instance.set_next_program_counter(ProgramCounter(0));
+    match_interrupt!(instance.run().unwrap(), InterruptKind::Trap);
+    assert_eq!(instance.program_counter(), Some(next_offsets[2]));
+}
+
 fn jump_into_middle_of_basic_block_from_outside(engine_config: Config) {
     let _ = env_logger::try_init();
     let engine = Engine::new(&engine_config).unwrap();
@@ -3865,6 +3887,8 @@ run_tests! {
 
     trapping_preserves_all_registers_normal_trap
     trapping_preserves_all_registers_segfault
+
+    out_of_range_execution
 
     memset_basic
     memset_with_dynamic_paging

--- a/fuzz/fuzz_targets/fuzz_polkavm.rs
+++ b/fuzz/fuzz_targets/fuzz_polkavm.rs
@@ -605,7 +605,7 @@ fn correctness_fuzzer_harness(data: Vec<OperationKind>) {
         //
 
         match interrupt_interpreter.clone() {
-            InterruptKind::NotEnoughGas | InterruptKind::Trap => {
+            InterruptKind::Finished | InterruptKind::NotEnoughGas | InterruptKind::Trap => {
                 break;
             }
             polkavm::InterruptKind::Ecalli(_) => {


### PR DESCRIPTION
Currently, the program counter always returns 0 when the last instruction is branch instruction and it evaluates to false. The correct behavior should be returning the faulting address.

This is also weird because the program counter returns correct value if the last instruction is something else.

Also, on re-compiler we do return correct faulting address.

This patch fixes interpreter behavior and makes it consistent with re-compiler.