### PR TITLE
Generic sandbox gas metering and signal handler fixes

### DIFF
--- a/crates/polkavm/src/compiler/amd64.rs
+++ b/crates/polkavm/src/compiler/amd64.rs
@@ -868,7 +868,10 @@ where
                 self.asm.push_raw(&[0x78, 0xf9]);
             } else {
                 assert_eq!(Self::vmctx_field(S::offset_table().gas), reg_indirect(RegSize::R64, r15 - 0xfa0)); // Sanity check.
-                debug_assert!(self.asm.code_mut().ends_with(&[0x49, 0x81, 0xaf, 0x60, 0xf0, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f]));
+                debug_assert!(self
+                    .asm
+                    .code_mut()
+                    .ends_with(&[0x49, 0x81, 0xaf, 0x60, 0xf0, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f]));
                 debug_assert_eq!(GAS_METERING_TRAP_OFFSET, (self.asm.len() - origin - 8) as u64);
                 self.asm.push_raw(&[0x78, 0xf6]);
             }


### PR DESCRIPTION
```
sandbox: Fix generic sandbox signal handler
Generic sandbox does correctly store register file on receiving signal.
This is fine in most cases, since there is no recovery after getting a
signal, but some of our tests assert register values after receiving a
signal.

For instance, if we run out of gas and trigger SIGILL, none of the
register values will be stored in Vmctx.
```

```
sandbox: Fix gas metering for the generic sandbox
Generic sandbox uses a different base register, instead of r15 pointing
to Vmctx, it points to start of guest memory. Vmctx base address is
calculated by [r15-4096]. This increases the number of bits required for
offset when emitting instructions for gas metering.

As a result, we need more bytes for the gas metering instructions.

Following patch reworks gas metering logic to accommodate this change.
```

After this change, only failing test cases are related to dynamic memory support.