### PR TITLE
Interpreter: Allow reclaiming cache backed memory in the interpreter backend

### DIFF
--- a/crates/polkavm/src/api.rs
+++ b/crates/polkavm/src/api.rs
@@ -1707,4 +1707,12 @@ impl RawInstance {
     pub fn next_native_program_counter(&self) -> Option<usize> {
         access_backend!(self.backend, |backend| backend.next_native_program_counter())
     }
+
+    /// Reset cache and therefore reclaim cache backed memory.
+    pub fn reset_interpreter_cache(&mut self) {
+        #[allow(irrefutable_let_patterns)]
+        if let InstanceBackend::Interpreted(ref mut backend) = self.backend {
+            backend.reset_interpreter_cache();
+        }
+    }
 }

--- a/crates/polkavm/src/interpreter.rs
+++ b/crates/polkavm/src/interpreter.rs
@@ -758,6 +758,19 @@ impl InterpretedInstance {
         }
     }
 
+    pub fn reset_interpreter_cache(&mut self) {
+        self.compiled_handlers.clear();
+        self.compiled_args.clear();
+
+        self.compiled_handlers.shrink_to_fit();
+        self.compiled_args.shrink_to_fit();
+
+        self.compiled_offset_for_block.reset();
+
+        self.compiled_offset = 0;
+        self.compile_out_of_range_stub();
+    }
+
     fn initialize_module(&mut self) {
         if self.module.gas_metering().is_some() {
             self.gas = 0;

--- a/tools/benchtool/Cargo.toml
+++ b/tools/benchtool/Cargo.toml
@@ -34,7 +34,6 @@ default = [
     "native",
     "pvf-executor",
     "solana_rbpf",
-    "wasm3",
     "wasmer",
     "wasmi",
     "wasmtime",


### PR DESCRIPTION
This commit adds the ability to reclaim cache backed memory in the interpreter backend of the PolkaVM. It deallocates compiled code and frees up memory previously allocated by the backend. This is useful for managing memory usage during the execution of multiple programs and limiting memory footprint of the all the programs in the memory.

The obvious side effect of this change is that the cache is cleared and the next program will have to be compiled again, which may lead to slower execution for the first run after reclaiming memory.


**without reclaim logic:**
```
running 1 test
[DEBUG polkavm::api] Selected backend: 'interpreter'
[TRACE polkavm::api] Creating new module from a 32-bit program blob
[TRACE polkavm::api] Checking imports...
[TRACE polkavm::api] Checking jump table...
[TRACE polkavm::api] Parsing exports...
[TRACE polkavm::api]   Export at 0: 'main'
[TRACE polkavm::api] Processing finished!
[DEBUG polkavm::api] Backend used: 'interpreted'
[DEBUG polkavm::api]   Memory map: RO data: 0x00010000..0x00010000 (0/0 bytes, non-zero until 0x00010000)
[DEBUG polkavm::api]   Memory map: RW data: 0x00020000..0x00020000 (0/0 bytes, non-zero until 0x00020000)
[DEBUG polkavm::api]   Memory map:   Stack: 0xfffe0000..0xfffe0000 (0/0 bytes)
[DEBUG polkavm::api]   Memory map:     Aux: 0xffff0000..0xffff0000 (0/0 bytes requested)
[TRACE polkavm::interpreter] Resolving arbitrary jump: 0
[TRACE polkavm::interpreter]   -> Found start of a basic block at: 0
[DEBUG polkavm::interpreter] Compiling block:
[DEBUG polkavm::interpreter]   [2]: 0: a0 = 0x1234
[DEBUG polkavm::interpreter]   [3]: 4: i32 a1 = a1 + 0x64
[DEBUG polkavm::interpreter]   [4]: 7: ecalli 0
[DEBUG polkavm::interpreter]   [5]: 8: a2 = 0x4567
[DEBUG polkavm::interpreter]   [6]: 12: ret
[DEBUG polkavm::interpreter] Starting execution at: 0 [2]
[TRACE polkavm::interpreter::raw_handlers] [2]: a0 = 0x1234
[TRACE polkavm::interpreter]   set: a0 = 0x1234
[TRACE polkavm::interpreter::raw_handlers] [3]: i32 a1 = a1 + 0x64
[TRACE polkavm::interpreter]   get: a1 = 0x0
[TRACE polkavm::interpreter]   set: a1 = 0x64
[TRACE polkavm::interpreter::raw_handlers] [4]: ecalli 0
[TRACE polkavm::api] Interrupted: Ecalli(0)
[DEBUG polkavm::interpreter] Starting execution at: 8 [5]
[TRACE polkavm::interpreter::raw_handlers] [5]: a2 = 0x4567
[TRACE polkavm::interpreter]   set: a2 = 0x4567
[TRACE polkavm::interpreter::raw_handlers] [6]: ret
[TRACE polkavm::interpreter]   get: ra = 0xffff0000
[TRACE polkavm::api] Interrupted: Finished
test tests::interpreter_reclaim_runtime_memory ... ok

```

**with reclaim logic:**
```
[DEBUG polkavm::api] Selected backend: 'interpreter'
[TRACE polkavm::api] Creating new module from a 32-bit program blob
[TRACE polkavm::api] Checking imports...
[TRACE polkavm::api] Checking jump table...
[TRACE polkavm::api] Parsing exports...
[TRACE polkavm::api]   Export at 0: 'main'
[TRACE polkavm::api] Processing finished!
[DEBUG polkavm::api] Backend used: 'interpreted'
[DEBUG polkavm::api]   Memory map: RO data: 0x00010000..0x00010000 (0/0 bytes, non-zero until 0x00010000)
[DEBUG polkavm::api]   Memory map: RW data: 0x00020000..0x00020000 (0/0 bytes, non-zero until 0x00020000)
[DEBUG polkavm::api]   Memory map:   Stack: 0xfffe0000..0xfffe0000 (0/0 bytes)
[DEBUG polkavm::api]   Memory map:     Aux: 0xffff0000..0xffff0000 (0/0 bytes requested)
[TRACE polkavm::interpreter] Resolving arbitrary jump: 0
[TRACE polkavm::interpreter]   -> Found start of a basic block at: 0
[DEBUG polkavm::interpreter] Compiling block:
[DEBUG polkavm::interpreter]   [2]: 0: a0 = 0x1234
[DEBUG polkavm::interpreter]   [3]: 4: i32 a1 = a1 + 0x64
[DEBUG polkavm::interpreter]   [4]: 7: ecalli 0
[DEBUG polkavm::interpreter]   [5]: 8: a2 = 0x4567
[DEBUG polkavm::interpreter]   [6]: 12: ret
[DEBUG polkavm::interpreter] Starting execution at: 0 [2]
[TRACE polkavm::interpreter::raw_handlers] [2]: a0 = 0x1234
[TRACE polkavm::interpreter]   set: a0 = 0x1234
[TRACE polkavm::interpreter::raw_handlers] [3]: i32 a1 = a1 + 0x64
[TRACE polkavm::interpreter]   get: a1 = 0x0
[TRACE polkavm::interpreter]   set: a1 = 0x64
[TRACE polkavm::interpreter::raw_handlers] [4]: ecalli 0
[TRACE polkavm::api] Interrupted: Ecalli(0)
[TRACE polkavm::interpreter] Resolving arbitrary jump: 8
[TRACE polkavm::interpreter]   -> Found start of a basic block at: 0
[DEBUG polkavm::interpreter] Compiling block:
[DEBUG polkavm::interpreter]   [2]: 0: a0 = 0x1234
[DEBUG polkavm::interpreter]   [3]: 4: i32 a1 = a1 + 0x64
[DEBUG polkavm::interpreter]   [4]: 7: ecalli 0
[DEBUG polkavm::interpreter]   [5]: 8: a2 = 0x4567
[DEBUG polkavm::interpreter]   [6]: 12: ret
[DEBUG polkavm::interpreter] Starting execution at: 8 [5]
[TRACE polkavm::interpreter::raw_handlers] [5]: a2 = 0x4567
[TRACE polkavm::interpreter]   set: a2 = 0x4567
[TRACE polkavm::interpreter::raw_handlers] [6]: ret
[TRACE polkavm::interpreter]   get: ra = 0xffff0000
[TRACE polkavm::api] Interrupted: Finished
test tests::interpreter_reclaim_runtime_memory ... ok
```

#310 