### PR TITLE
Bounded interpreter cache support

### DIFF
--- a/crates/polkavm/src/api.rs
+++ b/crates/polkavm/src/api.rs
@@ -1715,4 +1715,12 @@ impl RawInstance {
             backend.reset_interpreter_cache();
         }
     }
+
+    /// Set a lose upper limit on the interpreter cache size.
+    pub fn set_interpreter_cache_size(&mut self, max_cache_size: Option<usize>) {
+        #[allow(irrefutable_let_patterns)]
+        if let InstanceBackend::Interpreted(ref mut backend) = self.backend {
+            backend.set_interpreter_cache_size(max_cache_size);
+        }
+    }
 }

--- a/crates/polkavm/src/api.rs
+++ b/crates/polkavm/src/api.rs
@@ -83,6 +83,13 @@ impl<T> IntoResult<T> for T {
 
 pub type RegValue = u64;
 
+#[allow(clippy::exhaustive_structs)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct SetCacheSizeLimitArgs {
+    pub max_block_size: u32,
+    pub max_cache_size_bytes: usize,
+}
+
 #[derive(Copy, Clone)]
 pub struct RuntimeInstructionSet {
     allow_sbrk: bool,
@@ -1716,11 +1723,12 @@ impl RawInstance {
         }
     }
 
-    /// Set a lose upper limit on the interpreter cache size.
-    pub fn set_interpreter_cache_size(&mut self, max_cache_size: Option<usize>) {
+    /// Set a tight upper limit on the interpreter cache size (in bytes).
+    pub fn set_interpreter_cache_size_limit(&mut self, cache_info: Option<SetCacheSizeLimitArgs>) -> Result<(), Error> {
         #[allow(irrefutable_let_patterns)]
         if let InstanceBackend::Interpreted(ref mut backend) = self.backend {
-            backend.set_interpreter_cache_size(max_cache_size);
+            backend.set_interpreter_cache_size_limit(cache_info)?
         }
+        Ok(())
     }
 }

--- a/crates/polkavm/src/compiler.rs
+++ b/crates/polkavm/src/compiler.rs
@@ -199,7 +199,7 @@ where
             export_to_label = per_compilation_cache.export_to_label;
         } else {
             asm = Assembler::new();
-            program_counter_to_label = FlatMap::new(code_length + 2);
+            program_counter_to_label = FlatMap::new(code_length + 2, false);
             gas_metering_stub_offsets = Vec::new();
             gas_cost_for_basic_block = Vec::new();
             export_to_label = HashMap::new();

--- a/crates/polkavm/src/compiler.rs
+++ b/crates/polkavm/src/compiler.rs
@@ -43,7 +43,7 @@ const END_BASIC_BLOCK_INVALID: usize = 2;
 
 struct CachePerCompilation {
     assembler: Assembler,
-    program_counter_to_label: FlatMap<Label>,
+    program_counter_to_label: FlatMap<Label, false>,
     gas_metering_stub_offsets: Vec<usize>,
     gas_cost_for_basic_block: Vec<u32>,
     export_to_label: HashMap<u32, Label>,
@@ -93,7 +93,7 @@ where
     code: &'a [u8],
     bitmask: &'a [u8],
     asm: Assembler,
-    program_counter_to_label: FlatMap<Label>,
+    program_counter_to_label: FlatMap<Label, false>,
     step_tracing: bool,
     ecall_label: Label,
     export_to_label: HashMap<u32, Label>,
@@ -199,7 +199,7 @@ where
             export_to_label = per_compilation_cache.export_to_label;
         } else {
             asm = Assembler::new();
-            program_counter_to_label = FlatMap::new(code_length + 2, false);
+            program_counter_to_label = FlatMap::new(code_length + 2);
             gas_metering_stub_offsets = Vec::new();
             gas_cost_for_basic_block = Vec::new();
             export_to_label = HashMap::new();

--- a/crates/polkavm/src/interpreter.rs
+++ b/crates/polkavm/src/interpreter.rs
@@ -418,7 +418,7 @@ impl InterpretedInstance {
     pub fn new_from_module(module: Module, force_step_tracing: bool) -> Self {
         let step_tracing = module.is_step_tracing() || force_step_tracing;
         let mut instance = Self {
-            compiled_offset_for_block: FlatMap::new(module.code_len() + 1), // + 1 for one implicit out-of-bounds trap.
+            compiled_offset_for_block: FlatMap::new(module.code_len() + 1, true), // + 1 for one implicit out-of-bounds trap.
             compiled_handlers: Default::default(),
             compiled_args: Default::default(),
             module,

--- a/crates/polkavm/src/lib.rs
+++ b/crates/polkavm/src/lib.rs
@@ -131,14 +131,15 @@ pub mod debug_info {
 /// Miscellaneous types related to program blobs.
 pub mod program {
     pub use polkavm_common::program::{
-        ISA32_V1_NoSbrk, Imports, ImportsIter, Instruction, InstructionSet, Instructions, JumpTable, JumpTableIter, Opcode,
-        ParsedInstruction, ProgramExport, ProgramParseError, ProgramSymbol, RawReg, ISA32_V1, ISA64_V1,
+        EstimateInterpreterMemoryUsageArgs, ISA32_V1_NoSbrk, Imports, ImportsIter, Instruction, InstructionSet, Instructions, JumpTable,
+        JumpTableIter, Opcode, ParsedInstruction, ProgramExport, ProgramMemoryInfo, ProgramParseError, ProgramSymbol, RawReg, ISA32_V1,
+        ISA64_V1,
     };
 }
 
 pub type Gas = i64;
 
-pub use crate::api::{Engine, MemoryAccessError, Module, RawInstance, RegValue};
+pub use crate::api::{Engine, MemoryAccessError, Module, RawInstance, RegValue, SetCacheSizeLimitArgs};
 pub use crate::config::{BackendKind, Config, CustomCodegen, GasMeteringKind, ModuleConfig, SandboxKind};
 pub use crate::error::Error;
 pub use crate::gas::{Cost, CostModel, CostModelRef};


### PR DESCRIPTION
Add support for bounded interpreter cache and automatic cache reset when quota is exceeded.

Instead of adding a check in the instruction execution loop, we cleverly replace the first instruction of the new basic block with reset cache micro-instruction. This keeps the runner loop optimized. In addition, we make sure capacity of the interpreter cache never gets too big.

As you may notice, `max_cache_size` is not a tight upper bound, and transiently we could allocate more than `max_cache_size`. This is needed to keep the implementation optimized and complexity at bay.


Finally, we are also adding support to reset FlatMap and allocate its memory on first use.

**Testing**
```
running 1 test
[DEBUG polkavm::api] Selected backend: 'interpreter'
[TRACE polkavm::api] Creating new module from a 32-bit program blob
[TRACE polkavm::api] Checking imports...
[TRACE polkavm::api] Checking jump table...
[TRACE polkavm::api] Parsing exports...
[TRACE polkavm::api]   Export at 0: 'main'
[TRACE polkavm::api] Processing finished!
[DEBUG polkavm::api] Backend used: 'interpreted'
[DEBUG polkavm::api]   Memory map: RO data: 0x00010000..0x00010000 (0/0 bytes, non-zero until 0x00010000)
[DEBUG polkavm::api]   Memory map: RW data: 0x00020000..0x00020000 (0/0 bytes, non-zero until 0x00020000)
[DEBUG polkavm::api]   Memory map:   Stack: 0xfffe0000..0xfffe0000 (0/0 bytes)
[DEBUG polkavm::api]   Memory map:     Aux: 0xffff0000..0xffff0000 (0/0 bytes requested)
[TRACE polkavm::interpreter] Resolving arbitrary jump: 0
[TRACE polkavm::interpreter]   -> Found start of a basic block at: 0
[DEBUG polkavm::interpreter] Compiling block:
[DEBUG polkavm::interpreter]   [2]: 0: a0 = 0x1
[DEBUG polkavm::interpreter]   [3]: 3: a1 = 0x2
[DEBUG polkavm::interpreter]   [4]: 6: a2 = 0x3
[DEBUG polkavm::interpreter]   [5]: 9: jump 11
[DEBUG polkavm::interpreter] Starting execution at: 0 [2]
[TRACE polkavm::interpreter::raw_handlers] [2]: a0 = 0x1
[TRACE polkavm::interpreter]   set: a0 = 0x1
[TRACE polkavm::interpreter::raw_handlers] [3]: a1 = 0x2
[TRACE polkavm::interpreter]   set: a1 = 0x2
[TRACE polkavm::interpreter::raw_handlers] [4]: a2 = 0x3
[TRACE polkavm::interpreter]   set: a2 = 0x3
[TRACE polkavm::interpreter::raw_handlers] [5]: unresolved jump 11
[DEBUG polkavm::interpreter] Compiling block:
[DEBUG polkavm::interpreter]   [6]: 11: a3 = 0x4
[DEBUG polkavm::interpreter]   [7]: 14: a4 = 0x5
[DEBUG polkavm::interpreter]   [8]: 17: jump 19
[DEBUG polkavm::interpreter] Compiled handlers cache size exceeded at 6: 9 > 6; will reset the cache
[TRACE polkavm::interpreter::raw_handlers]   -> resolved to fallthrough
[TRACE polkavm::interpreter::raw_handlers] [6]: reset_cache
[DEBUG polkavm::interpreter] Compiling block:
[DEBUG polkavm::interpreter]   [2]: 11: a3 = 0x4
[DEBUG polkavm::interpreter]   [3]: 14: a4 = 0x5
[DEBUG polkavm::interpreter]   [4]: 17: jump 19
[TRACE polkavm::interpreter::raw_handlers] [2]: a3 = 0x4
[TRACE polkavm::interpreter]   set: a3 = 0x4
[TRACE polkavm::interpreter::raw_handlers] [3]: a4 = 0x5
[TRACE polkavm::interpreter]   set: a4 = 0x5
[TRACE polkavm::interpreter::raw_handlers] [4]: unresolved jump 19
[DEBUG polkavm::interpreter] Compiling block:
[DEBUG polkavm::interpreter]   [5]: 19: a5 = 0x6
[DEBUG polkavm::interpreter]   [6]: 22: ret
[DEBUG polkavm::interpreter] Compiled handlers cache size exceeded at 5: 7 > 6; will reset the cache
[TRACE polkavm::interpreter::raw_handlers]   -> resolved to fallthrough
[TRACE polkavm::interpreter::raw_handlers] [5]: reset_cache
[DEBUG polkavm::interpreter] Compiling block:
[DEBUG polkavm::interpreter]   [2]: 19: a5 = 0x6
[DEBUG polkavm::interpreter]   [3]: 22: ret
[TRACE polkavm::interpreter::raw_handlers] [2]: a5 = 0x6
[TRACE polkavm::interpreter]   set: a5 = 0x6
[TRACE polkavm::interpreter::raw_handlers] [3]: ret
[TRACE polkavm::interpreter]   get: ra = 0xffff0000
[TRACE polkavm::api] Interrupted: Finished
test tests::interpreter_bounded_interpreter_cache ... ok

```

Fixes: #315