### PR TITLE
Fuzz interpreter memory usage API

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,6 +101,8 @@ jobs:
       run: cd crates/polkavm-zygote && rustup component add rustfmt
     - name: Install rustfmt (guest-programs toolchain)
       run: cd guest-programs && rustup component add rustfmt
+    - name: Install rustfmt (fuzz toolchain)
+      run: cd fuzz && rustup component add rustfmt
     - name: Run rustfmt
       run: ./ci/jobs/rustfmt.sh
   pallet-revive-tests:

--- a/ci/jobs/fuzz.sh
+++ b/ci/jobs/fuzz.sh
@@ -17,3 +17,6 @@ cargo fuzz run fuzz_linker -- -runs=10000
 
 echo ">> cargo fuzz run (fuzz_polkavm)"
 cargo fuzz run fuzz_polkavm -- -runs=10000
+
+echo ">> cargo fuzz run (fuzz_program_blob)"
+cargo fuzz run fuzz_program_blob -- -runs=10000

--- a/ci/jobs/rustfmt.sh
+++ b/ci/jobs/rustfmt.sh
@@ -15,7 +15,10 @@ cd ../..
 
 echo ">> cargo fmt (guests)"
 cd guest-programs
-
 cargo fmt --check --all
+cd ..
 
-cd ../..
+echo ">> cargo fmt (fuzz)"
+cd fuzz
+cargo fmt --check --all
+cd ..

--- a/crates/polkavm-common/src/program.rs
+++ b/crates/polkavm-common/src/program.rs
@@ -4855,7 +4855,8 @@ impl ProgramBlob {
             } => (page_size, instruction_count, basic_block_count),
         };
 
-        let cache_entry_count_upper_bound = cast(instruction_count + basic_block_count + INTERPRETER_CACHE_RESERVED_ENTRIES).to_usize();
+        let cache_entry_count_upper_bound =
+            cast(instruction_count).to_usize() + cast(basic_block_count).to_usize() + INTERPRETER_CACHE_RESERVED_ENTRIES as usize;
         let cache_size_upper_bound = interpreter_calculate_cache_size(cache_entry_count_upper_bound);
 
         let mut purgeable_ram_consumption = match args {
@@ -4866,7 +4867,7 @@ impl ProgramBlob {
                 ..
             } => {
                 let max_cache_size_bytes = cast(max_cache_size_bytes).to_usize();
-                let cache_entry_count_hard_limit = cast(max_block_size + INTERPRETER_CACHE_RESERVED_ENTRIES).to_usize();
+                let cache_entry_count_hard_limit = cast(max_block_size).to_usize() + INTERPRETER_CACHE_RESERVED_ENTRIES as usize;
                 let cache_bytes_hard_limit = interpreter_calculate_cache_size(cache_entry_count_hard_limit);
                 if cache_bytes_hard_limit > max_cache_size_bytes {
                     return Err("maximum cache size is too small for the given max block size");

--- a/crates/polkavm/src/interpreter.rs
+++ b/crates/polkavm/src/interpreter.rs
@@ -514,7 +514,7 @@ impl InterpretedInstance {
             ));
         }
 
-        let compiled_handlers_soft_limit = compiled_handlers_hard_limit - cast(max_block_size + 1).to_usize();
+        let compiled_handlers_soft_limit = compiled_handlers_hard_limit - (cast(max_block_size).to_usize() + 1);
         self.max_compiled_handlers = Some(compiled_handlers_soft_limit);
         Ok(())
     }

--- a/crates/polkavm/src/interpreter.rs
+++ b/crates/polkavm/src/interpreter.rs
@@ -499,7 +499,7 @@ impl InterpretedInstance {
 
         // Calculate the minimum number of compiled handlers required to guarantee a tight upper bound.
         // We must be able to hold at least two basic blocks (including gas metering) and we should also account for precompiled stubs.
-        let minimum_compiled_handlers = cast((max_block_size + 1) * 2 + INTERPRETER_CACHE_RESERVED_ENTRIES).to_usize();
+        let minimum_compiled_handlers = (cast(max_block_size).to_usize() + 1) * 2 + INTERPRETER_CACHE_RESERVED_ENTRIES as usize;
 
         if compiled_handlers_hard_limit < minimum_compiled_handlers {
             log::debug!(

--- a/crates/polkavm/src/interpreter.rs
+++ b/crates/polkavm/src/interpreter.rs
@@ -499,7 +499,7 @@ impl InterpretedInstance {
 
         // Calculate the minimum number of compiled handlers required to guarantee a tight upper bound.
         // We must be able to hold at least two basic blocks (including gas metering) and we should also account for precompiled stubs.
-        let minimum_compiled_handlers = (cast(max_block_size).to_usize() + 1) * 2 + INTERPRETER_CACHE_RESERVED_ENTRIES as usize;
+        let minimum_compiled_handlers = (cast(max_block_size).to_usize() + 1) * 2 + cast(INTERPRETER_CACHE_RESERVED_ENTRIES).to_usize();
 
         if compiled_handlers_hard_limit < minimum_compiled_handlers {
             log::debug!(

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -49,6 +49,13 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "fuzz_program_blob"
+path = "fuzz_targets/fuzz_program_blob.rs"
+test = false
+doc = false
+bench = false
+
 [workspace]
 resolver = "2"
 members = ["."]

--- a/fuzz/fuzz_targets/fuzz_linker.rs
+++ b/fuzz/fuzz_targets/fuzz_linker.rs
@@ -3,7 +3,6 @@
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 
-
 #[repr(u8)]
 #[derive(Arbitrary, Debug)]
 pub enum Reg {
@@ -105,23 +104,9 @@ enum RegImmKind {
 
 #[derive(Arbitrary, Debug)]
 enum Instruction {
-    Reg {
-        kind: RegKind,
-        dst: Reg,
-        src: Reg
-    },
-    RegReg {
-        kind: RegRegKind,
-        dst: Reg,
-        src1: Reg,
-        src2: Reg,
-    },
-    RegImm {
-        kind: RegImmKind,
-        dst: Reg,
-        src: Reg,
-        imm: u32,
-    },
+    Reg { kind: RegKind, dst: Reg, src: Reg },
+    RegReg { kind: RegRegKind, dst: Reg, src1: Reg, src2: Reg },
+    RegImm { kind: RegImmKind, dst: Reg, src: Reg, imm: u32 },
 }
 
 fn serialize_instructions(data: Vec<Instruction>) -> Vec<u8> {
@@ -130,17 +115,17 @@ fn serialize_instructions(data: Vec<Instruction>) -> Vec<u8> {
         match instruction {
             Instruction::Reg { kind, dst, src } => {
                 let mut encoding: u32 = match kind {
-                    RegKind::CountLeadingZeroBits       => 0b0110000_00000_00000_001_00000_0010011,
+                    RegKind::CountLeadingZeroBits => 0b0110000_00000_00000_001_00000_0010011,
                     RegKind::CountLeadingZeroBitsInWord => 0b0110000_00000_00000_001_00000_0011011,
-                    RegKind::CountSetBits               => 0b0110000_00010_00000_001_00000_0010011,
-                    RegKind::CountSetBitsInWord         => 0b0110000_00010_00000_001_00000_0011011,
-                    RegKind::CountTrailingZeroBits      => 0b0110000_00001_00000_001_00000_0010011,
-                    RegKind::CountTrailingZeroBitsInWord=> 0b0110000_00001_00000_001_00000_0011011,
-                    RegKind::OrCombineByte              => 0b0010100_00111_00000_101_00000_0010011,
-                    RegKind::ReverseByte                => 0b0110101_11000_00000_101_00000_0010011,
-                    RegKind::SignExtend8                => 0b0110000_00100_00000_001_00000_0010011,
-                    RegKind::SignExtend16               => 0b0110000_00101_00000_001_00000_0010011,
-                    RegKind::ZeroExtend16               => 0b0000100_00000_00000_100_00000_0111011,
+                    RegKind::CountSetBits => 0b0110000_00010_00000_001_00000_0010011,
+                    RegKind::CountSetBitsInWord => 0b0110000_00010_00000_001_00000_0011011,
+                    RegKind::CountTrailingZeroBits => 0b0110000_00001_00000_001_00000_0010011,
+                    RegKind::CountTrailingZeroBitsInWord => 0b0110000_00001_00000_001_00000_0011011,
+                    RegKind::OrCombineByte => 0b0010100_00111_00000_101_00000_0010011,
+                    RegKind::ReverseByte => 0b0110101_11000_00000_101_00000_0010011,
+                    RegKind::SignExtend8 => 0b0110000_00100_00000_001_00000_0010011,
+                    RegKind::SignExtend16 => 0b0110000_00101_00000_001_00000_0010011,
+                    RegKind::ZeroExtend16 => 0b0000100_00000_00000_100_00000_0111011,
                 };
 
                 encoding |= (dst as u32) << 7;
@@ -149,49 +134,49 @@ fn serialize_instructions(data: Vec<Instruction>) -> Vec<u8> {
             }
             Instruction::RegReg { kind, dst, src1, src2 } => {
                 let mut encoding: u32 = match kind {
-                    RegRegKind::Add32AndSignExtend                      => 0b0000000_00000_00000_000_00000_0111011,
-                    RegRegKind::Sub32AndSignExtend                      => 0b0100000_00000_00000_000_00000_0111011,
-                    RegRegKind::Mul32AndSignExtend                      => 0b0000001_00000_00000_000_00000_0111011,
-                    RegRegKind::Div32AndSignExtend                      => 0b0000001_00000_00000_100_00000_0111011,
-                    RegRegKind::DivUnsigned32AndSignExtend              => 0b0000001_00000_00000_101_00000_0111011,
-                    RegRegKind::Rem32AndSignExtend                      => 0b0000001_00000_00000_110_00000_0111011,
-                    RegRegKind::RemUnsigned32AndSignExtend              => 0b0000001_00000_00000_111_00000_0111011,
-                    RegRegKind::ShiftLogicalLeft32AndSignExtend         => 0b0000000_00000_00000_001_00000_0111011,
-                    RegRegKind::ShiftLogicalRight32AndSignExtend        => 0b0000001_00000_00000_000_00000_0111011,
-                    RegRegKind::ShiftArithmeticRight32AndSignExtend     => 0b0100000_00000_00000_101_00000_0111011,
-                    RegRegKind::RotateLeft32AndSignExtend               => 0b0110000_00000_00000_001_00000_0111011,
-                    RegRegKind::RotateRight32AndSignExtend              => 0b0110000_00000_00000_101_00000_0111011,
+                    RegRegKind::Add32AndSignExtend => 0b0000000_00000_00000_000_00000_0111011,
+                    RegRegKind::Sub32AndSignExtend => 0b0100000_00000_00000_000_00000_0111011,
+                    RegRegKind::Mul32AndSignExtend => 0b0000001_00000_00000_000_00000_0111011,
+                    RegRegKind::Div32AndSignExtend => 0b0000001_00000_00000_100_00000_0111011,
+                    RegRegKind::DivUnsigned32AndSignExtend => 0b0000001_00000_00000_101_00000_0111011,
+                    RegRegKind::Rem32AndSignExtend => 0b0000001_00000_00000_110_00000_0111011,
+                    RegRegKind::RemUnsigned32AndSignExtend => 0b0000001_00000_00000_111_00000_0111011,
+                    RegRegKind::ShiftLogicalLeft32AndSignExtend => 0b0000000_00000_00000_001_00000_0111011,
+                    RegRegKind::ShiftLogicalRight32AndSignExtend => 0b0000001_00000_00000_000_00000_0111011,
+                    RegRegKind::ShiftArithmeticRight32AndSignExtend => 0b0100000_00000_00000_101_00000_0111011,
+                    RegRegKind::RotateLeft32AndSignExtend => 0b0110000_00000_00000_001_00000_0111011,
+                    RegRegKind::RotateRight32AndSignExtend => 0b0110000_00000_00000_101_00000_0111011,
 
-                    RegRegKind::Add64                                   => 0b0000000_00000_00000_000_00000_0110011,
-                    RegRegKind::Sub64                                   => 0b0100000_00000_00000_000_00000_0110011,
-                    RegRegKind::Mul64                                   => 0b0000001_00000_00000_000_00000_0110011,
-                    RegRegKind::Div64                                   => 0b0000001_00000_00000_100_00000_0110011,
-                    RegRegKind::DivUnsigned64                           => 0b0000001_00000_00000_101_00000_0110011,
-                    RegRegKind::Rem64                                   => 0b0000001_00000_00000_110_00000_0110011,
-                    RegRegKind::RemUnsigned64                           => 0b0000001_00000_00000_111_00000_0110011,
-                    RegRegKind::ShiftLogicalLeft64                      => 0b0000000_00000_00000_001_00000_0110011,
-                    RegRegKind::ShiftLogicalRight64                     => 0b0000000_00000_00000_101_00000_0110011,
-                    RegRegKind::ShiftArithmeticRight64                  => 0b0100000_00000_00000_101_00000_0110011,
-                    RegRegKind::RotateLeft64                            => 0b0110000_00000_00000_001_00000_0110011,
-                    RegRegKind::RotateRight64                           => 0b0110000_00000_00000_101_00000_0110011,
+                    RegRegKind::Add64 => 0b0000000_00000_00000_000_00000_0110011,
+                    RegRegKind::Sub64 => 0b0100000_00000_00000_000_00000_0110011,
+                    RegRegKind::Mul64 => 0b0000001_00000_00000_000_00000_0110011,
+                    RegRegKind::Div64 => 0b0000001_00000_00000_100_00000_0110011,
+                    RegRegKind::DivUnsigned64 => 0b0000001_00000_00000_101_00000_0110011,
+                    RegRegKind::Rem64 => 0b0000001_00000_00000_110_00000_0110011,
+                    RegRegKind::RemUnsigned64 => 0b0000001_00000_00000_111_00000_0110011,
+                    RegRegKind::ShiftLogicalLeft64 => 0b0000000_00000_00000_001_00000_0110011,
+                    RegRegKind::ShiftLogicalRight64 => 0b0000000_00000_00000_101_00000_0110011,
+                    RegRegKind::ShiftArithmeticRight64 => 0b0100000_00000_00000_101_00000_0110011,
+                    RegRegKind::RotateLeft64 => 0b0110000_00000_00000_001_00000_0110011,
+                    RegRegKind::RotateRight64 => 0b0110000_00000_00000_101_00000_0110011,
 
-                    RegRegKind::MulUpperSignedSigned64                  => 0b0000001_00000_00000_001_00000_0110011,
-                    RegRegKind::MulUpperSignedUnsigned64                => 0b0000001_00000_00000_010_00000_0110011,
-                    RegRegKind::MulUpperUnsignedUnsigned64              => 0b0000001_00000_00000_011_00000_0110011,
+                    RegRegKind::MulUpperSignedSigned64 => 0b0000001_00000_00000_001_00000_0110011,
+                    RegRegKind::MulUpperSignedUnsigned64 => 0b0000001_00000_00000_010_00000_0110011,
+                    RegRegKind::MulUpperUnsignedUnsigned64 => 0b0000001_00000_00000_011_00000_0110011,
 
-                    RegRegKind::SetLessThanSigned64                     => 0b0000000_00000_00000_010_00000_0110011,
-                    RegRegKind::SetLessThanUnsigned64                   => 0b0000000_00000_00000_011_00000_0110011,
-                    RegRegKind::Xor64                                   => 0b0000000_00000_00000_100_00000_0110011,
-                    RegRegKind::Or64                                    => 0b0000000_00000_00000_110_00000_0110011,
-                    RegRegKind::And64                                   => 0b0000000_00000_00000_111_00000_0110011,
+                    RegRegKind::SetLessThanSigned64 => 0b0000000_00000_00000_010_00000_0110011,
+                    RegRegKind::SetLessThanUnsigned64 => 0b0000000_00000_00000_011_00000_0110011,
+                    RegRegKind::Xor64 => 0b0000000_00000_00000_100_00000_0110011,
+                    RegRegKind::Or64 => 0b0000000_00000_00000_110_00000_0110011,
+                    RegRegKind::And64 => 0b0000000_00000_00000_111_00000_0110011,
 
-                    RegRegKind::Minimum                                 => 0b0000101_00000_00000_100_00000_0110011,
-                    RegRegKind::MinimumUnsigned                         => 0b0000101_00000_00000_101_00000_0110011,
-                    RegRegKind::Maximum                                 => 0b0000101_00000_00000_110_00000_0110011,
-                    RegRegKind::MaximumUnsigned                         => 0b0000101_00000_00000_111_00000_0110011,
-                    RegRegKind::Xnor                                    => 0b0100000_00000_00000_100_00000_0110011,
-                    RegRegKind::OrInverted                              => 0b0100000_00000_00000_110_00000_0110011,
-                    RegRegKind::AndInverted                             => 0b0100000_00000_00000_111_00000_0110011,
+                    RegRegKind::Minimum => 0b0000101_00000_00000_100_00000_0110011,
+                    RegRegKind::MinimumUnsigned => 0b0000101_00000_00000_101_00000_0110011,
+                    RegRegKind::Maximum => 0b0000101_00000_00000_110_00000_0110011,
+                    RegRegKind::MaximumUnsigned => 0b0000101_00000_00000_111_00000_0110011,
+                    RegRegKind::Xnor => 0b0100000_00000_00000_100_00000_0110011,
+                    RegRegKind::OrInverted => 0b0100000_00000_00000_110_00000_0110011,
+                    RegRegKind::AndInverted => 0b0100000_00000_00000_111_00000_0110011,
                 };
 
                 encoding |= (dst as u32) << 7;
@@ -201,24 +186,24 @@ fn serialize_instructions(data: Vec<Instruction>) -> Vec<u8> {
             }
             Instruction::RegImm { kind, dst, src, imm } => {
                 let mut encoding: u32 = match kind {
-                    RegImmKind::Add32AndSignExtend                  => 0b0000000_00000_00000_000_00000_0011011,
-                    RegImmKind::ShiftLogicalLeft32AndSignExtend     => 0b0000000_00000_00000_001_00000_0011011,
-                    RegImmKind::ShiftLogicalRight32AndSignExtend    => 0b0000000_00000_00000_101_00000_0011011,
+                    RegImmKind::Add32AndSignExtend => 0b0000000_00000_00000_000_00000_0011011,
+                    RegImmKind::ShiftLogicalLeft32AndSignExtend => 0b0000000_00000_00000_001_00000_0011011,
+                    RegImmKind::ShiftLogicalRight32AndSignExtend => 0b0000000_00000_00000_101_00000_0011011,
                     RegImmKind::ShiftArithmeticRight32AndSignExtend => 0b0100000_00000_00000_101_00000_0011011,
-                    RegImmKind::RotateRight32AndSignExtend          => 0b0110000_00000_00000_101_00000_0011011,
+                    RegImmKind::RotateRight32AndSignExtend => 0b0110000_00000_00000_101_00000_0011011,
 
-                    RegImmKind::ShiftLogicalLeft64                  => 0b0000000_00000_00000_001_00000_0010011,
-                    RegImmKind::ShiftLogicalRight64                 => 0b0000000_00000_00000_101_00000_0010011,
-                    RegImmKind::ShiftArithmeticRight64              => 0b0100000_00000_00000_101_00000_0010011,
+                    RegImmKind::ShiftLogicalLeft64 => 0b0000000_00000_00000_001_00000_0010011,
+                    RegImmKind::ShiftLogicalRight64 => 0b0000000_00000_00000_101_00000_0010011,
+                    RegImmKind::ShiftArithmeticRight64 => 0b0100000_00000_00000_101_00000_0010011,
 
-                    RegImmKind::RotateRight64                       => 0b0110000_00000_00000_101_00000_0010011,
+                    RegImmKind::RotateRight64 => 0b0110000_00000_00000_101_00000_0010011,
 
-                    RegImmKind::Add64                               => 0b0000000_00000_00000_000_00000_0010011,
-                    RegImmKind::SetLessThanSigned64                 => 0b0000000_00000_00000_010_00000_0010011,
-                    RegImmKind::SetLessThanUnsigned64               => 0b0000000_00000_00000_011_00000_0010011,
-                    RegImmKind::Xor64                               => 0b0000000_00000_00000_100_00000_0010011,
-                    RegImmKind::Or64                                => 0b0000000_00000_00000_110_00000_0010011,
-                    RegImmKind::And64                               => 0b0000000_00000_00000_111_00000_0010011,
+                    RegImmKind::Add64 => 0b0000000_00000_00000_000_00000_0010011,
+                    RegImmKind::SetLessThanSigned64 => 0b0000000_00000_00000_010_00000_0010011,
+                    RegImmKind::SetLessThanUnsigned64 => 0b0000000_00000_00000_011_00000_0010011,
+                    RegImmKind::Xor64 => 0b0000000_00000_00000_100_00000_0010011,
+                    RegImmKind::Or64 => 0b0000000_00000_00000_110_00000_0010011,
+                    RegImmKind::And64 => 0b0000000_00000_00000_111_00000_0010011,
                 };
 
                 let imm_mask: u32 = match kind {
@@ -292,80 +277,87 @@ struct Elf64Shdr {
 }
 
 fn create_minimal_elf(bytecode: &[u8]) -> Vec<u8> {
-
     assert!(std::mem::size_of::<Elf64Ehdr>() == 64);
     assert!(std::mem::size_of::<Elf64Phdr>() == 56);
     assert!(std::mem::size_of::<Elf64Shdr>() == 64);
 
     let elf_hdr = Elf64Ehdr {
         e_ident: [
-            0x7f, b'E', b'L', b'F',         // Magic number
-            2,                              // 64-bit
-            1,                              // Little-endian
-            1,                              // ELF version
-            0,                              // ABI
-            0,                              // ABI version
+            0x7f, b'E', b'L', b'F', // Magic number
+            2,    // 64-bit
+            1,    // Little-endian
+            1,    // ELF version
+            0,    // ABI
+            0,    // ABI version
             0, 0, 0, 0, 0, 0, 0,
         ],
-        e_type: 2,                          // Executable file
-        e_machine: 0xF3,                    // RISC-V architecture
-        e_version: 1,                       // ELF version
-        e_entry: 0x1000,                    // Entry point address
-        e_phoff: 0,                         // Program header table file offset
-        e_shoff: 64,                        // Section header table file offset
-        e_flags: 0,                         // Processor-specific flags
-        e_ehsize: 64,                       // ELF header size
-        e_phentsize: 0,                     // Program header table entry size
-        e_phnum: 0,                         // Number of program header entries
-        e_shentsize: 64,                    // Section header table entry size
-        e_shnum: 3,                         // Number of section header entries
-        e_shstrndx: 2,                      // Section header string table index
+        e_type: 2,       // Executable file
+        e_machine: 0xF3, // RISC-V architecture
+        e_version: 1,    // ELF version
+        e_entry: 0x1000, // Entry point address
+        e_phoff: 0,      // Program header table file offset
+        e_shoff: 64,     // Section header table file offset
+        e_flags: 0,      // Processor-specific flags
+        e_ehsize: 64,    // ELF header size
+        e_phentsize: 0,  // Program header table entry size
+        e_phnum: 0,      // Number of program header entries
+        e_shentsize: 64, // Section header table entry size
+        e_shnum: 3,      // Number of section header entries
+        e_shstrndx: 2,   // Section header string table index
     };
 
     let null_shdr = Elf64Shdr {
-        sh_name: 0,                         // Section name (index into the section header string table)
-        sh_type: 0,                         // Section type (NULL)
-        sh_flags: 0,                        // Section flags
-        sh_addr: 0,                         // Section virtual address
-        sh_offset: 0,                       // Section file offset
-        sh_size: 0,                         // Section size in file
-        sh_link: 0,                         // Link to another section
-        sh_info: 0,                         // Additional section information
-        sh_addralign: 0,                    // Section alignment
-        sh_entsize: 0,                      // Entry size if section holds table
+        sh_name: 0,      // Section name (index into the section header string table)
+        sh_type: 0,      // Section type (NULL)
+        sh_flags: 0,     // Section flags
+        sh_addr: 0,      // Section virtual address
+        sh_offset: 0,    // Section file offset
+        sh_size: 0,      // Section size in file
+        sh_link: 0,      // Link to another section
+        sh_info: 0,      // Additional section information
+        sh_addralign: 0, // Section alignment
+        sh_entsize: 0,   // Entry size if section holds table
     };
 
     let text_shdr = Elf64Shdr {
-        sh_name: 1,                         // Section name (index into the section header string table)
-        sh_type: 1,                         // Section type (PROGBITS)
-        sh_flags: 6,                        // Section flags (ALLOC + EXECINSTR)
-        sh_addr: 0x1000,                    // Section virtual address
-        sh_offset: 64 * 4 + 32,             // Section file offset
-        sh_size: bytecode.len() as u64,     // Section size in file
-        sh_link: 0,                         // Link to another section
-        sh_info: 0,                         // Additional section information
-        sh_addralign: 4,                    // Section alignment
-        sh_entsize: 0,                      // Entry size if section holds table
+        sh_name: 1,                     // Section name (index into the section header string table)
+        sh_type: 1,                     // Section type (PROGBITS)
+        sh_flags: 6,                    // Section flags (ALLOC + EXECINSTR)
+        sh_addr: 0x1000,                // Section virtual address
+        sh_offset: 64 * 4 + 32,         // Section file offset
+        sh_size: bytecode.len() as u64, // Section size in file
+        sh_link: 0,                     // Link to another section
+        sh_info: 0,                     // Additional section information
+        sh_addralign: 4,                // Section alignment
+        sh_entsize: 0,                  // Entry size if section holds table
     };
 
     let shstrtab_shdr = Elf64Shdr {
-        sh_name: 7,                         // Section name (index into the section header string table)
-        sh_type: 3,                         // Section type (STRTAB)
-        sh_flags: 0,                        // Section flags
-        sh_addr: 0,                         // Section virtual address
-        sh_offset: 64 * 4,                  // Section file offset
-        sh_size: 32,                        // Section size in file
-        sh_link: 0,                         // Link to another section
-        sh_info: 0,                         // Additional section information
-        sh_addralign: 1,                    // Section alignment
-        sh_entsize: 0,                      // Entry size if section holds table
+        sh_name: 7,        // Section name (index into the section header string table)
+        sh_type: 3,        // Section type (STRTAB)
+        sh_flags: 0,       // Section flags
+        sh_addr: 0,        // Section virtual address
+        sh_offset: 64 * 4, // Section file offset
+        sh_size: 32,       // Section size in file
+        sh_link: 0,        // Link to another section
+        sh_info: 0,        // Additional section information
+        sh_addralign: 1,   // Section alignment
+        sh_entsize: 0,     // Entry size if section holds table
     };
 
     let mut program = Vec::new();
-    program.extend_from_slice(unsafe { std::slice::from_raw_parts((&elf_hdr as *const Elf64Ehdr) as *const u8, std::mem::size_of::<Elf64Ehdr>()) });
-    program.extend_from_slice(unsafe { std::slice::from_raw_parts((&null_shdr as *const Elf64Shdr) as *const u8, std::mem::size_of::<Elf64Shdr>()) });
-    program.extend_from_slice(unsafe { std::slice::from_raw_parts((&text_shdr as *const Elf64Shdr) as *const u8, std::mem::size_of::<Elf64Shdr>()) });
-    program.extend_from_slice(unsafe { std::slice::from_raw_parts((&shstrtab_shdr as *const Elf64Shdr) as *const u8, std::mem::size_of::<Elf64Shdr>()) });
+    program.extend_from_slice(unsafe {
+        std::slice::from_raw_parts((&elf_hdr as *const Elf64Ehdr) as *const u8, std::mem::size_of::<Elf64Ehdr>())
+    });
+    program.extend_from_slice(unsafe {
+        std::slice::from_raw_parts((&null_shdr as *const Elf64Shdr) as *const u8, std::mem::size_of::<Elf64Shdr>())
+    });
+    program.extend_from_slice(unsafe {
+        std::slice::from_raw_parts((&text_shdr as *const Elf64Shdr) as *const u8, std::mem::size_of::<Elf64Shdr>())
+    });
+    program.extend_from_slice(unsafe {
+        std::slice::from_raw_parts((&shstrtab_shdr as *const Elf64Shdr) as *const u8, std::mem::size_of::<Elf64Shdr>())
+    });
     program.extend_from_slice(b"\0.text\0.shstrtab\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
     program.extend_from_slice(&bytecode);
 

--- a/fuzz/fuzz_targets/fuzz_program_blob.rs
+++ b/fuzz/fuzz_targets/fuzz_program_blob.rs
@@ -1,0 +1,57 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use polkavm_common::program::{EstimateInterpreterMemoryUsageArgs, ProgramBlob, ProgramParts};
+use polkavm_common::utils::ArcBytes;
+
+#[derive(Debug, Arbitrary)]
+struct FuzzParams {
+    ro_data_size: u32,
+    rw_data_size: u32,
+    code_size: u32,
+    stack_size: u32,
+
+    page_size: u32,
+    instruction_count: u32,
+    basic_block_count: u32,
+    max_cache_size_bytes: u32,
+    max_block_size: u32,
+    use_bounded_cache: bool,
+}
+
+fuzz_target!(|input: FuzzParams| {
+    // Limit sizes to reasonable values to avoid OOM during fuzzing
+    let alloc_ro_data_size = core::cmp::min(input.ro_data_size, 1024 * 1024) as usize;
+    let alloc_rw_data_size = core::cmp::min(input.rw_data_size, 1024 * 1024) as usize;
+    let alloc_code_size = core::cmp::min(input.code_size, 1024 * 1024) as usize;
+
+    let mut parts = ProgramParts::default();
+    parts.is_64_bit = true;
+    parts.ro_data_size = input.ro_data_size;
+    parts.rw_data_size = input.rw_data_size;
+    parts.stack_size = input.stack_size;
+    parts.ro_data = ArcBytes::from(vec![0; alloc_ro_data_size]);
+    parts.rw_data = ArcBytes::from(vec![0; alloc_rw_data_size]);
+    parts.code_and_jump_table = ArcBytes::from(vec![0; alloc_code_size]);
+
+    if let Ok(blob) = ProgramBlob::from_parts(parts) {
+        let args = if input.use_bounded_cache {
+            EstimateInterpreterMemoryUsageArgs::BoundedCache {
+                page_size: input.page_size,
+                instruction_count: input.instruction_count,
+                basic_block_count: input.basic_block_count,
+                max_cache_size_bytes: input.max_cache_size_bytes,
+                max_block_size: input.max_block_size,
+            }
+        } else {
+            EstimateInterpreterMemoryUsageArgs::UnboundedCache {
+                page_size: input.page_size,
+                instruction_count: input.instruction_count,
+                basic_block_count: input.basic_block_count,
+            }
+        };
+
+        let _ = blob.estimate_interpreter_memory_usage(args);
+    }
+});


### PR DESCRIPTION
```
fuzz: Add fuzz test for interpreter cache size limit

We update the existing polkavm fuzzing harness to includ an optional
parameter that will set the cache size limit for the interpreter.

This will help us identify any potential issues related to bounded
cache logic.

It also found a bug where u32 multiplication could overflow when
calculating the minimum number of compiled handlers.
```

```
fuzz: Add fuzz target for ProgramBlob estimate interpreter memory usage

This commit introduces a new fuzz target, `fuzz_program_blob`, designed
to test the `ProgramBlob::estimate_interpreter_memory_usage` function.
The fuzz target generates varied inputs to ensure the function can handle
a wide range of scenarios without panicking.

Fuzzing did find an issue with integer overflow in the cache size
calculation, which has been addressed in this commit.
```

Fixes: #320