### PR TITLE
Enable all generic sandbox tests except for memset

### DIFF
--- a/ci/jobs/build-and-test.sh
+++ b/ci/jobs/build-and-test.sh
@@ -32,10 +32,9 @@ done
 
 echo ">> cargo test (generic-sandbox)"
 cargo test --features generic-sandbox -p polkavm -- \
-    tests::compiler_generic_* \
+    tests::compiler_generic_ \
     --skip tests::compiler_generic_memset_basic \
-    --skip tests::compiler_generic_memset_with_dynamic_paging \
-    --skip tests::compiler_generic_pinky_dynamic_paging_64
+    --skip tests::compiler_generic_memset_with_dynamic_paging
 
 echo ">> cargo run (examples)"
 POLKAVM_TRACE_EXECUTION=1 POLKAVM_ALLOW_INSECURE=1 cargo run -p hello-world-host

--- a/ci/jobs/build-and-test.sh
+++ b/ci/jobs/build-and-test.sh
@@ -32,9 +32,10 @@ done
 
 echo ">> cargo test (generic-sandbox)"
 cargo test --features generic-sandbox -p polkavm -- \
-    tests::compiler_generic_basic_test \
-    tests::compiler_generic_simple_test \
-    tests::compiler_generic_riscv_ 
+    tests::compiler_generic_* \
+    --skip tests::compiler_generic_memset_basic \
+    --skip tests::compiler_generic_memset_with_dynamic_paging \
+    --skip tests::compiler_generic_pinky_dynamic_paging_64
 
 echo ">> cargo run (examples)"
 POLKAVM_TRACE_EXECUTION=1 POLKAVM_ALLOW_INSECURE=1 cargo run -p hello-world-host

--- a/crates/polkavm-assembler/src/amd64.rs
+++ b/crates/polkavm-assembler/src/amd64.rs
@@ -228,6 +228,11 @@ impl RegIndex {
             RegSize::R32 => self.name32(),
         }
     }
+
+    #[inline]
+    pub const fn equals(self, other: Self) -> bool {
+        (self as u8) == (other as u8)
+    }
 }
 
 impl core::fmt::Display for RegIndex {


### PR DESCRIPTION
```
    ci: Enable all generic sandbox tests except known failing ones
    
    While I fix the known failing tests, enable all other generic sandbox tests to
    ensure that we catch any regressions early.
```

```
   generic: Fix pinky dynamic paging test failure
    
    Pinky dynamic paging test was failing because of GPF after handling a
    page fault. On further investigation, it was found that the temporary
    register (rcx) was not being restored properly after handling a page
    fault. This causes the load address calculation to use a wrong value
    in rcx, leading to a GPF.
    
    This problem only exists on generic sandbox because we will never page
    fault in between of using TMP_REG on Linux sandbox.
    
    with this commit, we also enable the pinky dynamic paging test in CI.
```

...will post memset update as a seperate PR later.