### PR TITLE
Fix multiple issues related to generic-sandbox when running on MacOS aarch64

### DIFF
--- a/ci/jobs/build-and-test-linux.sh
+++ b/ci/jobs/build-and-test-linux.sh
@@ -24,6 +24,12 @@ POLKAVM_TRACE_EXECUTION=1 POLKAVM_ALLOW_INSECURE=1 POLKAVM_BACKEND=compiler POLK
 # echo ">> cargo run (examples, compiler, generic, x86_64-unknown-linux-gnu)"
 # POLKAVM_TRACE_EXECUTION=1 POLKAVM_ALLOW_INSECURE=1 POLKAVM_BACKEND=compiler POLKAVM_SANDBOX=generic cargo run --target=x86_64-unknown-linux-gnu -p hello-world-host
 
+echo ">> cargo test (generic-sandbox)"
+cargo test --features generic-sandbox -p polkavm -- \
+    tests::compiler_generic_ \
+    --skip tests::compiler_generic_memset_basic \
+    --skip tests::compiler_generic_memset_with_dynamic_paging
+
 echo ">> cargo check (polkatool, i686-unknown-linux-musl)"
 cargo check --target=i686-unknown-linux-musl -p polkatool
 

--- a/ci/jobs/build-and-test-macos.sh
+++ b/ci/jobs/build-and-test-macos.sh
@@ -14,3 +14,9 @@ POLKAVM_TRACE_EXECUTION=1 POLKAVM_ALLOW_INSECURE=1 POLKAVM_BACKEND=interpreter c
 
 echo ">> cargo run (examples, interpreter, aarch64-apple-darwin)"
 POLKAVM_TRACE_EXECUTION=1 POLKAVM_ALLOW_INSECURE=1 POLKAVM_BACKEND=interpreter cargo run --target=aarch64-apple-darwin -p hello-world-host
+
+echo ">> cargo test (generic-sandbox)"
+cargo test --features generic-sandbox -p polkavm -- \
+    tests::compiler_generic_ \
+    --skip tests::compiler_generic_memset_basic \
+    --skip tests::compiler_generic_memset_with_dynamic_paging

--- a/ci/jobs/build-and-test.sh
+++ b/ci/jobs/build-and-test.sh
@@ -30,12 +30,6 @@ do
     cd tools/benchtool && cargo test --profile $PROFILE && cd ../..
 done
 
-echo ">> cargo test (generic-sandbox)"
-cargo test --features generic-sandbox -p polkavm -- \
-    tests::compiler_generic_ \
-    --skip tests::compiler_generic_memset_basic \
-    --skip tests::compiler_generic_memset_with_dynamic_paging
-
 echo ">> cargo run (examples)"
 POLKAVM_TRACE_EXECUTION=1 POLKAVM_ALLOW_INSECURE=1 cargo run -p hello-world-host
 


### PR DESCRIPTION
```
generic-sandbox: Fix signal handling on macOS

ucontext_t is different on macOS and Linux. On macOS, SIGSEGV is not
sent for page faults, instead SIGBUS is sent. This commit updates the
signal handler to check for SIGBUS on macOS.

Finally, we also fix the page fault address extraction on macOS.

Signed-off-by: Aman <aman@parity.io>
```
---
```
generic-sandbox: Fix invalid jump detection on macOS / Rosetta 2

On Rosetta 2, indirect jump to a non-canonical address doesn't trigger
a page fault (SIGBUS) right away. Instead, it jumps to the address, and then
triggers a page fault (SIGBUS) when trying to fetch the instruction.

This means that previous program counter is now lost, and now we have no
way of detecting if the guest program triggered an invalid jump or not.

We fix this program by updating the vmctx before making the jump and in
the signal handler we check if the current program counter is non-canonical.

Signed-off-by: Aman <aman@parity.io>
```
---
```
ci: Run generic-sandbox tests in CI on aarch64 MacOS using Rosetta 2

Signed-off-by: Aman <aman@parity.io>
```