### PR TITLE
fix(common): gate native register reverse mapping

### DIFF
--- a/crates/polkavm-common/src/regmap.rs
+++ b/crates/polkavm-common/src/regmap.rs
@@ -93,6 +93,7 @@ pub const TMP_REG: NativeReg = polkavm_assembler::aarch64::Reg::x16;
 /// On the generic sandbox, this holds the guest memory base address.
 pub const AUX_TMP_REG: NativeReg = polkavm_assembler::aarch64::Reg::x17;
 
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 #[inline]
 pub const fn to_guest_reg(reg: NativeReg) -> Option<Reg> {
     let mut index = 0;


### PR DESCRIPTION
## Problem

The AArch64 JIT branch defines the reverse native-register map for every target, but `NativeReg` and `to_native_reg` only exist on x86_64 and aarch64. Building `polkavm-common` for wasm32 therefore fails with E0425.

## Change

Compile `to_guest_reg` only on the two native JIT architectures, matching the symbols it consumes.

## Verification

- `cargo check -p polkavm-common --target wasm32-unknown-unknown`